### PR TITLE
fix broken binary uploads by not setting "utf-8" encoding when reading file

### DIFF
--- a/lib/util.js
+++ b/lib/util.js
@@ -22,15 +22,6 @@ const fs = require('fs');
  */
 function createReadStream(path, options) {
     return new Promise((resolve, reject) => {
-        if(typeof options === 'string' || options instanceof String){
-            options = { encoding: options };
-        }
-        if(typeof options === 'object') { // ensure flags are here                
-            options = {flags: 'r',
-                encoding: 'utf8',
-                mode: 0o444, ...options};
-        }
-
         const readStream = fs.createReadStream(path, options);
         readStream.on('open', () => {
             resolve(readStream);
@@ -51,15 +42,6 @@ function createReadStream(path, options) {
  */
 function createWriteStream(path, options) {
     return new Promise((resolve, reject) => {
-        if(typeof options === 'string' || options instanceof String){
-            options = { encoding: options };
-        }
-        if(typeof options === 'object') { // ensure flags are here                
-            options = {flags: 'w',
-                encoding: 'utf8',
-                mode: 0o222, ...options};
-        }
-
         const writeStream = fs.createWriteStream(path, options);
         writeStream.on('open', () => {
             resolve(writeStream);


### PR DESCRIPTION
## Description

Binary uploads were broken since https://github.com/adobe/node-httptransfer/commit/7ffed5a430a4dc764ee322f774b5b1b6a711e16f. Problem is that it started to treat all files as character files by setting `utf-8` encoding in `createReadStream()`.

- reverted previous changes to set `options` in `util.createReadStream()`
  and `util.createWriteStream()` meant to fix Windows
  - encoding: don't set as we treat all files as binary
  - flags: was using the default values, can be left out
  - mode: this only applies when files are created, defaults are fine (at least for unit tests here, including on Windows)
  - string for options: never used in codebase
- added test `status-201-2urls binary`


## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
