### PR TITLE
multipart upload require maxPartSize

### DIFF
--- a/lib/aemmultipart.js
+++ b/lib/aemmultipart.js
@@ -53,7 +53,34 @@ async function uploadAEMMultipartFile(filepath, target, options) {
     } else if (target.minPartSize && target.maxPartSize && (target.minPartSize > target.maxPartSize)) {
         throw Error(`minPartSize (${target.minPartSize}) > maxPartSize: (${target.maxPartSize})`);
     }
-    const partSize = await calculatePartSize(filepath, target, options);
+
+    // Calculate the partSize based on the number of urls
+    const { size } = await fs.stat(filepath);
+    let partSize = Math.ceil(size / target.urls.length);
+
+    // Make sure that the file is not too large
+    if (target.maxPartSize && (partSize > target.maxPartSize)) {
+        throw Error(`File '${filepath}' is too large to upload: ${size} bytes, maxPartSize: ${target.maxPartSize} bytes, numUploadURIs: ${target.urls.length}`);
+    }
+
+    // Default to the maxPartSize
+    // Limit the lower bound to the minPartSize, since the estimated file size to generate uris
+    // may be significantly larger than the actual file size. Also make sure that partSize is positive.
+    partSize = Math.max(
+        partSize,
+        target.maxPartSize || 1,
+        target.minPartSize || 1,
+        1
+    );
+
+    // Override using the user provided partSize, clamp its value to ensure that its at least
+    // the minimum calculated (otherwise there are not enough urls or the blocks are too small).
+    if (options && options.partSize) {
+        partSize = Math.max(partSize, options.partSize);
+        partSize = (target.maxPartSize && Math.min(partSize, target.maxPartSize)) || partSize;
+    }
+    console.log('THIS IS THE PART SIZE', partSize);
+
     // extract upload options
     const uploadOptions = filterObject(
         options || {},
@@ -77,33 +104,6 @@ async function uploadAEMMultipartFile(filepath, target, options) {
         start += length;
         ++i;
     }
-}
-
-async function calculatePartSize(filepath, target, options) {
-    // Calculate the partSize based on the number of urls
-    const { size } = await fs.stat(filepath);
-    let partSize = Math.ceil(size / target.urls.length);
-
-    // Make sure that the file is not too large
-    if (target.maxPartSize && (partSize > target.maxPartSize)) {
-        throw Error(`File '${filepath}' is too large to upload: ${size} bytes, maxPartSize: ${target.maxPartSize} bytes, numUploadURIs: ${target.urls.length}`);
-    }
-
-    // Limit the lower bound to the minPartSize, since the estimated file size to generate uris
-    // may be significantly larger than the actual file size. Also make sure that partSize is positive.
-    partSize = Math.max(
-        partSize,
-        target.minPartSize || 1,
-        1
-    );
-
-    // Override using the user provided partSize, clamp its value to ensure that its at least
-    // the minimum calculated (otherwise there are not enough urls or the blocks are too small).
-    if (options && options.partSize) {
-        partSize = Math.max(partSize, options.partSize);
-        partSize = (target.maxPartSize && Math.min(partSize, target.maxPartSize)) || partSize;
-    }
-    return partSize;
 }
 
 module.exports = {

--- a/lib/aemmultipart.js
+++ b/lib/aemmultipart.js
@@ -53,31 +53,7 @@ async function uploadAEMMultipartFile(filepath, target, options) {
     } else if (target.minPartSize && target.maxPartSize && (target.minPartSize > target.maxPartSize)) {
         throw Error(`minPartSize (${target.minPartSize}) > maxPartSize: (${target.maxPartSize})`);
     }
-
-    // Calculate the partSize based on the number of urls
-    const { size } = await fs.stat(filepath);
-    let partSize = Math.ceil(size / target.urls.length);
-
-    // Make sure that the file is not too large
-    if (target.maxPartSize && (partSize > target.maxPartSize)) {
-        throw Error(`File '${filepath}' is too large to upload: ${size} bytes, maxPartSize: ${target.maxPartSize} bytes, numUploadURIs: ${target.urls.length}`);
-    }
-
-    // Limit the lower bound to the minPartSize, since the estimated file size to generate uris
-    // may be significantly larger than the actual file size. Also make sure that partSize is positive.
-    partSize = Math.max(
-        partSize,
-        target.minPartSize || 1,
-        1
-    );
-
-    // Override using the user provided partSize, clamp its value to ensure that its at least
-    // the minimum calculated (otherwise there are not enough urls or the blocks are too small).
-    if (options && options.partSize) {
-        partSize = Math.max(partSize, options.partSize);
-        partSize = (target.maxPartSize && Math.min(partSize, target.maxPartSize)) || partSize;
-    }
-
+    const partSize = await calculatePartSize(filepath, target, options);
     // extract upload options
     const uploadOptions = filterObject(
         options || {},
@@ -101,6 +77,33 @@ async function uploadAEMMultipartFile(filepath, target, options) {
         start += length;
         ++i;
     }
+}
+
+async function calculatePartSize(filepath, target, options) {
+    // Calculate the partSize based on the number of urls
+    const { size } = await fs.stat(filepath);
+    let partSize = Math.ceil(size / target.urls.length);
+
+    // Make sure that the file is not too large
+    if (target.maxPartSize && (partSize > target.maxPartSize)) {
+        throw Error(`File '${filepath}' is too large to upload: ${size} bytes, maxPartSize: ${target.maxPartSize} bytes, numUploadURIs: ${target.urls.length}`);
+    }
+
+    // Limit the lower bound to the minPartSize, since the estimated file size to generate uris
+    // may be significantly larger than the actual file size. Also make sure that partSize is positive.
+    partSize = Math.max(
+        partSize,
+        target.minPartSize || 1,
+        1
+    );
+
+    // Override using the user provided partSize, clamp its value to ensure that its at least
+    // the minimum calculated (otherwise there are not enough urls or the blocks are too small).
+    if (options && options.partSize) {
+        partSize = Math.max(partSize, options.partSize);
+        partSize = (target.maxPartSize && Math.min(partSize, target.maxPartSize)) || partSize;
+    }
+    return partSize;
 }
 
 module.exports = {

--- a/lib/aemmultipart.js
+++ b/lib/aemmultipart.js
@@ -32,7 +32,6 @@ const filterObject = require('filter-obj');
  * @typedef {Object} UploadAEMMultipartTarget
  *
  * @property {String[]} urls URLs
- * @property {Number} [minPartSize] Minimum size of each part
  * @property {Number} [maxPartSize] Maximum size of each part
  */
 /**
@@ -50,8 +49,8 @@ async function uploadAEMMultipartFile(filepath, target, options) {
         throw Error('target not provided');
     } else if (!target.urls || target.urls.length === 0) {
         throw Error('invalid number of target urls');
-    } else if (target.minPartSize && target.maxPartSize && (target.minPartSize > target.maxPartSize)) {
-        throw Error(`minPartSize (${target.minPartSize}) > maxPartSize: (${target.maxPartSize})`);
+    } else if (!target.maxPartSize) {
+        throw Error('maxPartSize not provided');
     }
 
     // Calculate the partSize based on the number of urls
@@ -59,26 +58,12 @@ async function uploadAEMMultipartFile(filepath, target, options) {
     let partSize = Math.ceil(size / target.urls.length);
 
     // Make sure that the file is not too large
-    if (target.maxPartSize && (partSize > target.maxPartSize)) {
+    if (partSize > target.maxPartSize) {
         throw Error(`File '${filepath}' is too large to upload: ${size} bytes, maxPartSize: ${target.maxPartSize} bytes, numUploadURIs: ${target.urls.length}`);
     }
 
     // Default to the maxPartSize
-    // Limit the lower bound to the minPartSize, since the estimated file size to generate uris
-    // may be significantly larger than the actual file size. Also make sure that partSize is positive.
-    partSize = Math.max(
-        partSize,
-        target.maxPartSize || 1,
-        target.minPartSize || 1,
-        1
-    );
-
-    // Override using the user provided partSize, clamp its value to ensure that its at least
-    // the minimum calculated (otherwise there are not enough urls or the blocks are too small).
-    if (options && options.partSize) {
-        partSize = Math.max(partSize, options.partSize);
-        partSize = (target.maxPartSize && Math.min(partSize, target.maxPartSize)) || partSize;
-    }
+    partSize = target.maxPartSize;
     console.log('part size:', partSize);
 
     // extract upload options

--- a/lib/aemmultipart.js
+++ b/lib/aemmultipart.js
@@ -79,7 +79,7 @@ async function uploadAEMMultipartFile(filepath, target, options) {
         partSize = Math.max(partSize, options.partSize);
         partSize = (target.maxPartSize && Math.min(partSize, target.maxPartSize)) || partSize;
     }
-    console.log('THIS IS THE PART SIZE', partSize);
+    console.log('part size:', partSize);
 
     // extract upload options
     const uploadOptions = filterObject(

--- a/test/aemmultipart.test.js
+++ b/test/aemmultipart.test.js
@@ -58,19 +58,17 @@ describe('multipart', function () {
                 console.log(e);
             }
         });
-        it('min-part-size larger than max-part-size', async function () {
+        it('max-part-size is missing', async function () {
             await fs.writeFile('test-transfer-file-3.dat', 'hello world 123', 'utf8');
 
             try {
                 await uploadAEMMultipartFile('test-transfer-file-3.dat', {
                     urls: [
                         'http://test-status-201/path/to/file-1.ext',
-                    ],
-                    minPartSize: 1000,
-                    maxPartSize: 500
+                    ]
                 });
             } catch (e) {
-                assert.equal(e.message, 'minPartSize (1000) > maxPartSize: (500)');
+                assert.equal(e.message, 'maxPartSize not provided');
             }
 
             try {
@@ -90,7 +88,8 @@ describe('multipart', function () {
             await uploadAEMMultipartFile('test-transfer-file-4.dat', {
                 urls: [
                     'http://test-status-201/path/to/file-1.ext'
-                ]
+                ],
+                maxPartSize: 15
             });
 
             try {
@@ -115,7 +114,8 @@ describe('multipart', function () {
                 urls: [
                     'http://test-status-201/path/to/file-1.ext',
                     'http://test-status-201/path/to/file-2.ext'
-                ]
+                ],
+                maxPartSize: 8
             });
 
             try {
@@ -145,7 +145,6 @@ describe('multipart', function () {
                     'http://test-status-201/path/to/file-1.ext',
                     'http://test-status-201/path/to/file-2.ext'
                 ],
-                minPartSize: 50,
                 maxPartSize: 50
             });
 
@@ -204,28 +203,6 @@ describe('multipart', function () {
                 console.log(e);
             }
         });
-        it('status-201-2urls-fitminpart', async function () {
-            await fs.writeFile('test-transfer-file-8.dat', 'hello world 123', 'utf8');
-
-            nock('http://test-status-201')
-                .matchHeader('content-length', 15)
-                .put('/path/to/file-1.ext', 'hello world 123')
-                .reply(201);
-
-            await uploadAEMMultipartFile('test-transfer-file-8.dat', {
-                minPartSize: 15,
-                urls: [
-                    'http://test-status-201/path/to/file-1.ext',
-                    'http://test-status-201/path/to/file-2.ext'
-                ]
-            });
-
-            try {
-                await fs.unlink('test-transfer-file-8.dat');
-            } catch (e) { // ignore cleanup failures
-                console.log(e);
-            }
-        });
         it('status-201-10urls-fits2', async function () {
             await fs.writeFile('test-transfer-file-9.dat', 'hello world 123', 'utf8');
 
@@ -239,7 +216,7 @@ describe('multipart', function () {
                 .reply(201);
 
             await uploadAEMMultipartFile('test-transfer-file-9.dat', {
-                minPartSize: 8,
+                maxPartSize: 8,
                 urls: [
                     'http://test-status-201/path/to/file-1.ext',
                     'http://test-status-201/path/to/file-2.ext',
@@ -260,146 +237,7 @@ describe('multipart', function () {
                 console.log(e);
             }
         });
-        it('status-201-2urls-minparttoosmall', async function () {
-            await fs.writeFile('test-transfer-file-10.dat', 'hello world 123', 'utf8');
-
-            // this works, because min part is only a suggestion
-            nock('http://test-status-201')
-                .matchHeader('content-length', 8)
-                .put('/path/to/file-1.ext', 'hello wo')
-                .reply(201);
-            nock('http://test-status-201')
-                .matchHeader('content-length', 7)
-                .put('/path/to/file-2.ext', 'rld 123')
-                .reply(201);
-
-            await uploadAEMMultipartFile('test-transfer-file-10.dat', {
-                minPartSize: 7,
-                urls: [
-                    'http://test-status-201/path/to/file-1.ext',
-                    'http://test-status-201/path/to/file-2.ext'
-                ]
-            });
-
-            try {
-                await fs.unlink('test-transfer-file-10.dat');
-            } catch (e) { // ignore cleanup failures
-                console.log(e);
-            }
-        });
-        it('status-201-2urls-smallerpreferred', async function () {
-            await fs.writeFile('test-transfer-file-11.dat', 'hello world 123', 'utf8');
-
-            nock('http://test-status-201')
-                .matchHeader('content-length', 8)
-                .put('/path/to/file-1.ext', 'hello wo')
-                .reply(201);
-            nock('http://test-status-201')
-                .matchHeader('content-length', 7)
-                .put('/path/to/file-2.ext', 'rld 123')
-                .reply(201);
-
-            await uploadAEMMultipartFile('test-transfer-file-11.dat', {
-                urls: [
-                    'http://test-status-201/path/to/file-1.ext',
-                    'http://test-status-201/path/to/file-2.ext'
-                ]
-            }, {
-                partSize: 7,
-            });
-
-            try {
-                await fs.unlink('test-transfer-file-11.dat');
-            } catch (e) { // ignore cleanup failures
-                console.log(e);
-            }
-        });
-        it('status-201-2urls-largerpreferred', async function () {
-            await fs.writeFile('test-transfer-file-12.dat', 'hello world 123', 'utf8');
-
-            nock('http://test-status-201')
-                .matchHeader('content-length', 9)
-                .put('/path/to/file-1.ext', 'hello wor')
-                .reply(201);
-            nock('http://test-status-201')
-                .matchHeader('content-length', 6)
-                .put('/path/to/file-2.ext', 'ld 123')
-                .reply(201);
-
-            await uploadAEMMultipartFile('test-transfer-file-12.dat', {
-                urls: [
-                    'http://test-status-201/path/to/file-1.ext',
-                    'http://test-status-201/path/to/file-2.ext'
-                ]
-            }, {
-                partSize: 9,
-            });
-
-            try {
-                await fs.unlink('test-transfer-file-12.dat');
-            } catch (e) { // ignore cleanup failures
-                console.log(e);
-            }
-        });
-        it('status-201-2urls-preferred-smallerminsize', async function () {
-            await fs.writeFile('test-transfer-file-13.dat', 'hello world 123', 'utf8');
-
-            // minPartSize smaller than preferred has no effect
-            nock('http://test-status-201')
-                .matchHeader('content-length', 9)
-                .put('/path/to/file-1.ext', 'hello wor')
-                .reply(201);
-            nock('http://test-status-201')
-                .matchHeader('content-length', 6)
-                .put('/path/to/file-2.ext', 'ld 123')
-                .reply(201);
-
-            await uploadAEMMultipartFile('test-transfer-file-13.dat', {
-                minPartSize: 8,
-                urls: [
-                    'http://test-status-201/path/to/file-1.ext',
-                    'http://test-status-201/path/to/file-2.ext'
-                ]
-            }, {
-                partSize: 9,
-            });
-
-            try {
-                await fs.unlink('test-transfer-file-13.dat');
-            } catch (e) { // ignore cleanup failures
-                console.log(e);
-            }
-        });
-        it('status-201-2urls-preferred-largerminsize', async function () {
-            await fs.writeFile('test-transfer-file-14.dat', 'hello world 123', 'utf8');
-
-            // preferred is limited on the lower-bound by minPartSize, so
-            // the picked part size is the minPartSize
-            nock('http://test-status-201')
-                .matchHeader('content-length', 9)
-                .put('/path/to/file-1.ext', 'hello wor')
-                .reply(201);
-            nock('http://test-status-201')
-                .matchHeader('content-length', 6)
-                .put('/path/to/file-2.ext', 'ld 123')
-                .reply(201);
-
-            await uploadAEMMultipartFile('test-transfer-file-14.dat', {
-                minPartSize: 9,
-                urls: [
-                    'http://test-status-201/path/to/file-1.ext',
-                    'http://test-status-201/path/to/file-2.ext'
-                ]
-            }, {
-                partSize: 8,
-            });
-
-            try {
-                await fs.unlink('test-transfer-file-14.dat');
-            } catch (e) { // ignore cleanup failures
-                console.log(e);
-            }
-        });
+       
         it('status-201-2urls-preferred-smallermaxsize', async function () {
             await fs.writeFile('test-transfer-file-15.dat', 'hello world 123', 'utf8');
 
@@ -472,7 +310,8 @@ describe('multipart', function () {
                     urls: [
                         'http://test-status-404/path/to/file-1.ext',
                         'http://test-status-404/path/to/file-2.ext'
-                    ]
+                    ],
+                    maxPartSize: 8,
                 });
             } catch (e) {
                 assert.ok(e.message.includes('PUT'));
@@ -502,7 +341,8 @@ describe('multipart', function () {
                     urls: [
                         'http://test-status-404/path/to/file-1.ext',
                         'http://test-status-404/path/to/file-2.ext'
-                    ]
+                    ],
+                    maxPartSize: 8,
                 });
             } catch (e) {
                 assert.ok(e.message.includes('PUT'));
@@ -531,7 +371,8 @@ describe('multipart', function () {
                 urls: [
                     'http://test-method-post/path/to/file-1.ext',
                     'http://test-method-post/path/to/file-2.ext'
-                ]
+                ],
+                maxPartSize: 8,
             }, {
                 method: 'POST'
             });
@@ -556,7 +397,8 @@ describe('multipart', function () {
                     urls: [
                         'http://timeout-error/path/to/file-1.ext',
                         'http://timeout-error/path/to/file-2.ext'
-                    ]
+                    ],
+                    maxPartSize: 8,
                 }, {
                     timeout: 200,
                     retryEnabled: false
@@ -593,7 +435,8 @@ describe('multipart', function () {
                     urls: [
                         'http://timeout-error/path/to/file-1.ext',
                         'http://timeout-error/path/to/file-2.ext'
-                    ]
+                    ],
+                    maxPartSize: 8,
                 }, {
                     timeout: 200,
                     retryEnabled: false
@@ -630,7 +473,8 @@ describe('multipart', function () {
                 urls: [
                     'http://header-override/path/to/file-1.ext',
                     'http://header-override/path/to/file-2.ext'
-                ]
+                ],
+                maxPartSize: 8,
             }, {
                 headers: {
                     "content-type": "image/jpeg"
@@ -667,7 +511,8 @@ describe('multipart', function () {
                 urls: [
                     'http://status-404-retry/path/to/file-1.ext',
                     'http://status-404-retry/path/to/file-2.ext'
-                ]
+                ],
+                maxPartSize: 8,
             }, {
                 retryAllErrors: true
             });
@@ -702,7 +547,8 @@ describe('multipart', function () {
                 urls: [
                     'http://status-503-retry/path/to/file-1.ext',
                     'http://status-503-retry/path/to/file-2.ext'
-                ]
+                ],
+                maxPartSize: 8,
             });
 
             try {
@@ -713,35 +559,4 @@ describe('multipart', function () {
         }).timeout(10000);
     });
 
-
-    it('favor max-part-size when min and max-part-size both defined', async function () {
-        await fs.writeFile('test-transfer-file-16.dat', 'hello world 123', 'utf8');
-
-        // preferred is limited on the lower-bound by minPartSize, so
-        // the picked part size is the minPartSize
-        nock('http://test-status-201')
-            .matchHeader('content-length', 8)
-            .put('/path/to/file-1.ext', 'hello wo')
-            .reply(201);
-        nock('http://test-status-201')
-            .matchHeader('content-length', 7)
-            .put('/path/to/file-2.ext', 'rld 123')
-            .reply(201);
-
-        await uploadAEMMultipartFile('test-transfer-file-16.dat', {
-            maxPartSize: 8,
-            minPartSize: 7,
-            urls: [
-                'http://test-status-201/path/to/file-1.ext',
-                'http://test-status-201/path/to/file-2.ext'
-            ]
-        }, {
-        });
-
-        try {
-            await fs.unlink('test-transfer-file-16.dat');
-        } catch (e) { // ignore cleanup failures
-            console.log(e);
-        }
-    });
 });


### PR DESCRIPTION
## Description

`maxPartSize` must be defined.
it will always choose `maxPartSize`. no more `options.partSize`, no more `minPartSize`

node 12
<img width="875" alt="Screen Shot 2020-11-11 at 3 07 15 PM" src="https://user-images.githubusercontent.com/20048485/98874735-ad085780-242f-11eb-8a1b-da757b0ad90a.png">

node 10
<img width="873" alt="Screen Shot 2020-11-11 at 3 08 10 PM" src="https://user-images.githubusercontent.com/20048485/98874756-b7c2ec80-242f-11eb-9442-12e9d1a0d6dd.png">



## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
