### PR TITLE
NUI-919 retryMaxDuration bug fix multipart upload

### DIFF
--- a/lib/aemmultipart.js
+++ b/lib/aemmultipart.js
@@ -70,7 +70,7 @@ async function uploadAEMMultipartFile(filepath, target, options) {
     const uploadOptions = filterObject(
         options || {},
         [ 'method', 'timeout', 'headers',
-            'retryMax', 'retryInterval', 'retryEnabled', 'retryAllErrors' ]
+            'retryMaxDuration', 'retryInterval', 'retryEnabled', 'retryAllErrors' ]
     );
 
     // upload blocks

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@adobe/httptransfer",
-  "version": "1.0.1",
+  "version": "2.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {


### PR DESCRIPTION
## Description
Multipart upload was passing threw the incorrect value for max retry duration: `retryMax` instead of `retryMaxDuration`

retry params multipart upload passes in:
https://github.com/adobe/node-httptransfer/blob/master/lib/aemmultipart.js#L73 (see retryMax )
vs what the retry function looks at:
https://github.com/adobe/node-httptransfer/blob/master/lib/retry.js#L77 (retryMaxDuration)

Fixes # https://jira.corp.adobe.com/browse/NUI-919

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
