### PR TITLE
Add missing return values

### DIFF
--- a/lib/headers.js
+++ b/lib/headers.js
@@ -46,6 +46,8 @@ function getLastModified(headers) {
     const lastModified = Date.parse(headers.get(HTTP.HEADER.LAST_MODIFIED));
     if (!isNaN(lastModified)) {
         return lastModified;
+    } else {
+        return undefined;
     }
 }
 
@@ -59,6 +61,8 @@ function getETag(headers) {
     const etag = headers.get(HTTP.HEADER.ETAG);
     if (etag && !etag.startsWith("W/")) {
         return etag;
+    } else {
+        return undefined;
     }
 }
 
@@ -85,6 +89,7 @@ function getContentDisposition(headers) {
             console.warn(`Unable to parse 'content-disposition' header: ${value}`, e.message || e);
         }
     }
+    return undefined;
 }
 
 /**
@@ -118,6 +123,7 @@ function getContentType(headers) {
             console.warn(`Unable to parse 'content-type' header: ${value}`, e.message || e);
         }
     }
+    return undefined;
 }
 
 /**
@@ -148,6 +154,8 @@ function getContentRange(headers) {
     const contentRange = headers.get(HTTP.HEADER.CONTENT_RANGE);
     if (contentRange) {
         return parseContentRange(contentRange);
+    } else {
+        return undefined;
     }
 }
 
@@ -165,6 +173,7 @@ function getContentLength(headers) {
             return parsed;
         }
     }
+    return undefined;
 }
 
 /**


### PR DESCRIPTION
These are not strictly neccesary because without a `return` the function result will be undefined, however it is confusing to leave them out.
