### PR TITLE
fix error when using windows-style file paths.

### DIFF
--- a/lib/filehandle.js
+++ b/lib/filehandle.js
@@ -16,21 +16,7 @@ require("core-js/stable");
 
 const fs = require("fs");
 
-/**
- * Open a file handle
- * 
- * @param {String|URL} path File path, or file:// url
- * @param {FileFlags} flags File flags to open (readonly, writeonly)
- * @returns {FileHandle} file handle
- */
-function toFilePath(path) {
-    if ((typeof path === "string") && !path.startsWith("file://")) {
-        return path;
-    } else {
-        const url = new URL(path);
-        return decodeURIComponent(url.pathname);
-    }
-}
+const { fileUrlToFilePath } = require("./util");
 
 /**
  * File open flags
@@ -82,7 +68,7 @@ class FileHandle {
      */
     static async open(path, flags) {
         return new Promise((resolve, reject) => {
-            const filePath = toFilePath(path);
+            const filePath = fileUrlToFilePath(path);
             const openFlags = (flags === FileFlags.WRITEONLY) ? "w" : "r";
             fs.open(filePath, openFlags, (err, fd) => {
                 if (err) {

--- a/lib/util.js
+++ b/lib/util.js
@@ -96,10 +96,36 @@ function isValidNumber(value) {
     return (typeof value === "number") && !isNaN(value);
 }
 
+/**
+ * Converts one of several potential values to a local file path.
+ * If the value is a string and does _not_ begin with "file://", then
+ * the value will be returned as-is. Otherwise the value is assumed to
+ * be a file URL, and the method will return the local path represented
+ * by the URL.
+ * @param {URL|string} path Value whose path should be retrieved.
+ * @returns {string} A local file path.
+ */
+function fileUrlToFilePath(path) {
+    if ((typeof path === "string") && !path.startsWith("file://")) {
+        return path;
+    } else {
+        const url = new URL(path);
+        let filePath = decodeURIComponent(url.pathname);
+        // windows paths will have a forward slash followed by
+        // the drive letter. strip off the leading forward slash
+        // if it appears to be a windows path (i.e. starts with "/C:/")
+        if (/^\/[a-zA-Z]:\//g.exec(filePath)) {
+            filePath = filePath.substr(1);
+        }
+        return filePath;
+    }
+}
+
 module.exports = {
     getFileStats,
     createReadStream,
     createWriteStream,
     isFileProtocol,
-    isValidNumber
+    isValidNumber,
+    fileUrlToFilePath
 };

--- a/test/util.test.js
+++ b/test/util.test.js
@@ -87,4 +87,9 @@ describe("util", function() {
     it('file-protocol-url-http', function() {
         assert.ok(!util.isFileProtocol(new URL('http://www.host.com')));
     });
+    it('file url to file path', function() {
+        assert.equal(util.fileUrlToFilePath('/test/path'), '/test/path');
+        assert.equal(util.fileUrlToFilePath('file:///test/path'), '/test/path');
+        assert.equal(util.fileUrlToFilePath('file:///C:/test/path'), 'C:/test/path');
+    });
 });


### PR DESCRIPTION
## Description

Fixes a crash in the module when attempting to use Windows-style paths; for example: `C:\path\to\some\file.jpg`. The root of the issue was that converting the example path to a file URL would yield `file:///C:/path/to/some/file.jpg` (note the extra `/` in front of `C:`. When attempting to retrieve the path from the file URL, the module was getting `/C:/path/to/some/file.jpg`, which caused `fs.open()` to fail with a message similar to "Cannot find path C:\C:\path\to\some\file.jpg" (note the duplicated drive letter).

I updated the module so that it will strip off the leading `/` if the referenced path looks like a windows path. The criteria for "looking like a windows path" is "the value starts with a forward slash, followed by a single upper-case or lower-case letter, followed by a single colon, followed by another forward slash."

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- ~[ ] My change requires a change to the documentation.~
- ~[ ] I have updated the documentation accordingly.~
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
