### PR TITLE
add aemdownload class for downloading assets.

### DIFF
--- a/lib/aemdownload.js
+++ b/lib/aemdownload.js
@@ -12,15 +12,11 @@
 
 'use strict';
 
-require("core-js/stable");
-
 const fileUrl = require("file-url");
 const { Asset } = require("./asset/asset");
 const { TransferAsset } = require("./asset/transferasset");
 const { AssetMetadata } = require("./asset/assetmetadata");
 const { TransferController, TransferEvents } = require("./transfercontroller");
-const { AEMInitiateUpload } = require("./functions/aeminitiateupload");
-const { AEMCompleteUpload } = require("./functions/aemcompleteupload");
 const { CreateTransferParts } = require("./functions/transferpartscreate");
 const { JoinTransferParts } = require("./functions/transferpartsjoin");
 const { CloseFiles } = require("./functions/closefiles");
@@ -28,67 +24,61 @@ const { MapConcurrent } = require("./generator/mapconcurrent");
 const { Transfer } = require("./functions/transfer");
 const { executePipeline, Pipeline } = require("./generator/pipeline");
 const { RandomFileAccess } = require("./randomfileaccess");
+const { URL } = require("url");
 const EventEmitter = require("events");
 
 /**
- * Generate AEM upload transfer assets
+ * Generate AEM download transfer assets
  * 
  * @generator
- * @param {AEMUploadOptions} options 
+ * @param {AEMDownloadOptions} options 
  * @yields {TransferAsset} Transfer asset
  */
-async function* generateAEMUploadTransferRecords(options) {
-    for (const uploadFile of options.uploadFiles) {
-        const sourceUrl = fileUrl(uploadFile.filePath);
-        const targetUrl = new URL(uploadFile.fileUrl);
+async function* generateAEMDownloadTransferRecords(options) {
+    for (const downloadFile of options.downloadFiles) {
+        const sourceUrl = new URL(downloadFile.fileUrl);
+        const targetUrl = fileUrl(downloadFile.filePath);
 
-        const source = new Asset(sourceUrl);
-        const target = new Asset(targetUrl, options.headers);
+        const source = new Asset(sourceUrl, options.headers);
+        const target = new Asset(targetUrl);
 
         const transferAsset = new TransferAsset(source, target, {
             acceptRanges: true,
-            metadata: new AssetMetadata(uploadFile.filePath, undefined, uploadFile.fileSize)
+            metadata: new AssetMetadata(downloadFile.filePath, undefined, downloadFile.fileSize)
         });
 
         yield transferAsset;
     }
 }
 
-class AEMUpload extends EventEmitter {
+class AEMDownload extends EventEmitter {
 
     /**
-     * @typedef {Object} UploadFile
-     * @property {String} fileUrl AEM url where to upload the file
-     * @property {Number} fileSize Size of the file to upload
-     * @property {String} filePath Path on the local disk to upload
-     * @property {Blob} [blob] Browser blob to upload (instead of fileUrl)
-     * @property {Boolean} [createVersion=false] Create version on duplicates
-     * @property {String} [versionLabel] Version label to apply to the created/updated file
-     * @property {String} [versionComment] Version comment to apply to the created/updated file
-     * @property {Boolean} [replace=false] True if the existing file should be replaced
+     * @typedef {Object} DownloadFile
+     * @property {String} fileUrl AEM url of file to download
+     * @property {String} filePath Path on the local disk where to download
+     * @property {Number} fileSize Size of the file being downloaded
      */
     /**
-     * @typedef {Object} AEMUploadOptions
-     * @property {UploadFile[]} uploadFiles List of files that will be uploaded to the target URL. 
-     * @property {*} headers HTTP headers that will be included in each request sent to AEM
-     * @property {Boolean} concurrent If true, multiple files in the supplied list of upload files will transfer simultaneously. If false, only one file will transfer at a time, and the next file will not begin transferring until the current file finishes.
+     * @typedef {Object} AEMDownloadOptions
+     * @property {DownloadFile[]} downloadFiles List of files that will be downloaded.
+     * @property {*} headers HTTP headers that will be included in each request sent to AEM.
+     * @property {Boolean} concurrent If true, multiple files in the supplied list of download files will transfer simultaneously. If false, only one file will transfer at a time, and the next file will not begin transferring until the current file finishes.
      * @property {Number} maxConcurrent Maximum number of concurrent HTTP requests that are allowed
      * @property {Number} [preferredPartSize] Preferred part size
      */
     /**
-     * Upload files to AEM
+     * Download files from AEM to local disk
      * 
-     * @param {AEMUploadOptions} options AEM upload options
+     * @param {AEMDownloadOptions} options AEM download options
      */
-    async uploadFiles(options) {
+    async downloadFiles(options) {
         const preferredPartSize = options && options.preferredPartSize;
         const maxConcurrent = (options && options.concurrent && options.maxConcurrent) || 1;
 
         const controller = new TransferController();
-        controller.on(TransferEvents.BEFORE_INITIATE_UPLOAD, ({ transferAssets }) => {
-            for (const transferAsset of transferAssets) {
-                this.emit("filestart", transferAsset.eventData);
-            }
+        controller.on(TransferEvents.TRANSFER_START, ({ transferAsset }) => {
+            this.emit("filestart", transferAsset.eventData);
         });
         controller.on(TransferEvents.TRANSFER_PROGRESS, ({ transferAsset, transferBytes }) => {
             this.emit("fileprogress", {
@@ -96,7 +86,7 @@ class AEMUpload extends EventEmitter {
                 transferred: transferBytes
             });
         });
-        controller.on(TransferEvents.AFTER_COMPLETE_UPLOAD, ({ transferAsset }) => {
+        controller.on(TransferEvents.TRANSFER_COMPLETE, ({ transferAsset }) => {
             this.emit("fileend", transferAsset.eventData);
         });
 
@@ -104,14 +94,12 @@ class AEMUpload extends EventEmitter {
         const randomFileAccess = new RandomFileAccess();
         try {
             const pipeline = new Pipeline(
-                new MapConcurrent(new AEMInitiateUpload(controller), { maxBatchLength: 100 }),
                 new CreateTransferParts({ preferredPartSize }),
                 new MapConcurrent(new Transfer(randomFileAccess), { maxConcurrent }),
                 new JoinTransferParts(controller),
                 new CloseFiles(randomFileAccess),
-                new MapConcurrent(new AEMCompleteUpload(controller)),
             );
-            await executePipeline(pipeline, generateAEMUploadTransferRecords(options));
+            await executePipeline(pipeline, generateAEMDownloadTransferRecords(options));
         } finally {
             await randomFileAccess.close();
         }
@@ -119,5 +107,5 @@ class AEMUpload extends EventEmitter {
 }
 
 module.exports = {
-    AEMUpload
+    AEMDownload
 };

--- a/lib/aemdownload.js
+++ b/lib/aemdownload.js
@@ -94,7 +94,7 @@ class AEMDownload extends EventEmitter {
         const randomFileAccess = new RandomFileAccess();
         try {
             const pipeline = new Pipeline(
-                new CreateTransferParts({ preferredPartSize }),
+                new CreateTransferParts({ preferredPartSize }, controller),
                 new MapConcurrent(new Transfer(randomFileAccess), { maxConcurrent }),
                 new JoinTransferParts(controller),
                 new CloseFiles(randomFileAccess),

--- a/lib/asset/transferasset.js
+++ b/lib/asset/transferasset.js
@@ -18,6 +18,7 @@ const { Asset } = require("./asset");
 const { AssetMetadata } = require("./assetmetadata");
 const { AssetMultipart } = require("./assetmultipart");
 const { AssetVersion } = require("./assetversion");
+const { MIMETYPE } = require("../constants");
 
 const PRIVATE = Symbol("PRIVATE");
 
@@ -166,7 +167,7 @@ class TransferAsset {
         };
 
         if (this.metadata.contentType) {
-            data.mimeType = this.metadata.contentType;
+            data.mimeType = this.metadata.contentType || MIMETYPE.APPLICATION_OCTET_STREAM;
         }
 
         return data;

--- a/lib/asset/transferasset.js
+++ b/lib/asset/transferasset.js
@@ -12,6 +12,8 @@
 
 "use strict";
 
+const { dirname: urlPathDirname, basename: urlPathBasename } = require("path").posix;
+
 const { Asset } = require("./asset");
 const { AssetMetadata } = require("./assetmetadata");
 const { AssetMultipart } = require("./assetmultipart");
@@ -148,6 +150,26 @@ class TransferAsset {
      */
     get multipartTarget() {
         return this[PRIVATE].multipartTarget;
+    }
+
+    /**
+     * Create a file event information for events sent by the module.
+     *
+     * @returns {*} File event data.
+     */
+    get eventData() {
+        const data = {
+            fileName: decodeURI(urlPathBasename(this.target.url.pathname)),
+            fileSize: this.metadata.contentLength,
+            targetFolder: decodeURI(urlPathDirname(this.target.url.pathname)),
+            targetFile: decodeURI(this.target.url.pathname)
+        };
+
+        if (this.metadata.contentType) {
+            data.mimeType = this.metadata.contentType;
+        }
+
+        return data;
     }
 
     /**

--- a/lib/asset/transferpart.js
+++ b/lib/asset/transferpart.js
@@ -30,9 +30,10 @@ class TransferPart {
      * @param {TransferAsset} transferAsset Transfer asset
      * @param {URL[]} targetUrls Target urls for this part
      * @param {DRange} contentRange Range for this part
-     * @param {Headers} [headers] Headers to send when storing content in the target urls
+     * @param {Headers} [sourceHeaders] Headers to send when interacting with the source
+     * @param {Headers} [targetHeaders] Headers to send when interacting with the target
      */
-    constructor(transferAsset, targetUrls, contentRange, headers) {
+    constructor(transferAsset, targetUrls, contentRange, sourceHeaders, targetHeaders) {
         if (!(transferAsset instanceof TransferAsset)) {
             throw Error(`Invalid transfer asset: ${transferAsset}`);
         }
@@ -46,7 +47,8 @@ class TransferPart {
             transferAsset,
             targetUrls,
             contentRange,
-            headers
+            sourceHeaders,
+            targetHeaders
         };
     }
 
@@ -83,12 +85,21 @@ class TransferPart {
     }
 
     /**
-     * Headers to send when storing content in the target urls
+     * Headers to send when interacting with the source
      * 
-     * @returns {Headers} Headers to send when storing content in the target urls
+     * @returns {Headers} Headers to send when interacting with the source
      */
-    get headers() {
-        return this[PRIVATE].headers;
+    get sourceHeaders() {
+        return this[PRIVATE].sourceHeaders;
+    }
+
+    /**
+     * Headers to send when interacting with the target
+     * 
+     * @returns {Headers} Headers to send when interacting with the target
+     */
+    get targetHeaders() {
+        return this[PRIVATE].targetHeaders;
     }
 
     /**

--- a/lib/asset/transferpart.js
+++ b/lib/asset/transferpart.js
@@ -30,10 +30,9 @@ class TransferPart {
      * @param {TransferAsset} transferAsset Transfer asset
      * @param {URL[]} targetUrls Target urls for this part
      * @param {DRange} contentRange Range for this part
-     * @param {Headers} [sourceHeaders] Headers to send when interacting with the source
-     * @param {Headers} [targetHeaders] Headers to send when interacting with the target
+     * @param {Headers} [targetHeaders] Headers to send when storing content in the target urls
      */
-    constructor(transferAsset, targetUrls, contentRange, sourceHeaders, targetHeaders) {
+    constructor(transferAsset, targetUrls, contentRange, targetHeaders) {
         if (!(transferAsset instanceof TransferAsset)) {
             throw Error(`Invalid transfer asset: ${transferAsset}`);
         }
@@ -47,7 +46,6 @@ class TransferPart {
             transferAsset,
             targetUrls,
             contentRange,
-            sourceHeaders,
             targetHeaders
         };
     }
@@ -90,7 +88,7 @@ class TransferPart {
      * @returns {Headers} Headers to send when interacting with the source
      */
     get sourceHeaders() {
-        return this[PRIVATE].sourceHeaders;
+        return this[PRIVATE].transferAsset.source.headers;
     }
 
     /**

--- a/lib/asset/transferpart.js
+++ b/lib/asset/transferpart.js
@@ -92,9 +92,9 @@ class TransferPart {
     }
 
     /**
-     * Headers to send when interacting with the target
-     * 
-     * @returns {Headers} Headers to send when interacting with the target
+     * Headers to send when storing content in the target urls
+     *
+     * @returns {Headers} Headers to send when storing content in the target urls
      */
     get targetHeaders() {
         return this[PRIVATE].targetHeaders;

--- a/lib/functions/transfer.js
+++ b/lib/functions/transfer.js
@@ -13,7 +13,7 @@
 "use strict";
 
 const { AsyncGeneratorFunction } = require("../generator/function");
-const { isFileProtocol, streamToBuffer } = require("../util");
+const { isFileProtocol } = require("../util");
 const { issuePut, streamGet } = require("../fetch");
 const { retry } = require("../retry");
 const { HTTP } = require("../constants");
@@ -90,11 +90,22 @@ class Transfer extends AsyncGeneratorFunction {
                     const totalSize = transferPart.metadata.contentLength;
                     const response = await streamGet(transferPart.source.url, {
                         headers: Object.assign({
-                            [HTTP.HEADER.CONTENT_RANGE]: `${HTTP.RANGE.BYTES} ${contentRange.low}-${contentRange.high}/${totalSize}`
+                            [HTTP.HEADER.RANGE]: `${HTTP.RANGE.BYTES}=${contentRange.low}-${contentRange.high}`
                         }, transferPart.sourceHeaders)
                     });
-                    const buffer = await streamToBuffer(response.body);
-                    await this.randomFileAccess.write(targetUrl, contentRange, buffer, totalSize);
+                    const contentLength = response.headers.get(HTTP.HEADER.CONTENT_LENGTH);
+
+                    // there have been cases where the server does not honor the range header.
+                    // since we'll be reading the entire response into memory, protect against accidentally
+                    // reading a very large amount of data into memory. For example, if the server responds with
+                    // an entire 1GB file even though we only requested a portion of that file, avoid reading
+                    // the whole 1GB into memory.
+                    const actualContentDifference = contentLength - contentRange.length;
+                    if (actualContentDifference > 0) {
+                        throw Error(`Server does not seem to have respected Range header. Actual content length is ${contentLength}B, which is ${actualContentDifference}B larger than requested range of ${contentRange.low}-${contentRange.high}.`);
+                    }
+
+                    await this.randomFileAccess.writeStream(targetUrl, contentRange, response.body, totalSize);
                 });
             }
             yield transferPart;

--- a/lib/functions/transfer.js
+++ b/lib/functions/transfer.js
@@ -13,8 +13,8 @@
 "use strict";
 
 const { AsyncGeneratorFunction } = require("../generator/function");
-const { isFileProtocol } = require("../util");
-const { issuePut } = require("../fetch");
+const { isFileProtocol, streamToBuffer } = require("../util");
+const { issuePut, streamGet } = require("../fetch");
 const { retry } = require("../retry");
 const { HTTP } = require("../constants");
 
@@ -70,7 +70,7 @@ class Transfer extends AsyncGeneratorFunction {
                         headers: Object.assign({
                             [HTTP.HEADER.CONTENT_LENGTH]: buf.length,
                             [HTTP.HEADER.CONTENT_TYPE]: transferPart.metadata.contentType
-                        }, transferPart.headers)
+                        }, transferPart.targetHeaders)
                     });    
                 }, this.options);
             } else if (transferPart.source.blob && targetUrl) {
@@ -82,9 +82,20 @@ class Transfer extends AsyncGeneratorFunction {
                         headers: Object.assign({
                             [HTTP.HEADER.CONTENT_LENGTH]: blob.size,
                             [HTTP.HEADER.CONTENT_TYPE]: transferPart.metadata.contentType
-                        }, transferPart.headers)
+                        }, transferPart.targetHeaders)
                     });
                 }, this.options);
+            } else if (targetUrl && isFileProtocol(targetUrl) && transferPart.source.url) {
+                await retry(async () => {
+                    const totalSize = transferPart.metadata.contentLength;
+                    const response = await streamGet(transferPart.source.url, {
+                        headers: Object.assign({
+                            [HTTP.HEADER.CONTENT_RANGE]: `${HTTP.RANGE.BYTES} ${contentRange.low}-${contentRange.high}/${totalSize}`
+                        }, transferPart.sourceHeaders)
+                    });
+                    const buffer = await streamToBuffer(response.body);
+                    await this.randomFileAccess.write(targetUrl, contentRange, buffer, totalSize);
+                });
             }
             yield transferPart;
         }

--- a/lib/functions/transfer.js
+++ b/lib/functions/transfer.js
@@ -13,7 +13,7 @@
 "use strict";
 
 const { AsyncGeneratorFunction } = require("../generator/function");
-const { isFileProtocol } = require("../util");
+const { isFileProtocol, streamToBuffer } = require("../util");
 const { issuePut, streamGet } = require("../fetch");
 const { retry } = require("../retry");
 const { HTTP } = require("../constants");
@@ -93,7 +93,7 @@ class Transfer extends AsyncGeneratorFunction {
                             [HTTP.HEADER.RANGE]: `${HTTP.RANGE.BYTES}=${contentRange.low}-${contentRange.high}`
                         }, transferPart.sourceHeaders)
                     });
-                    const contentLength = response.headers.get(HTTP.HEADER.CONTENT_LENGTH);
+                    const contentLength = Number.parseInt(response.headers.get(HTTP.HEADER.CONTENT_LENGTH), 10);
 
                     // there have been cases where the server does not honor the range header.
                     // since we'll be reading the entire response into memory, protect against accidentally
@@ -105,7 +105,8 @@ class Transfer extends AsyncGeneratorFunction {
                         throw Error(`Server does not seem to have respected Range header. Actual content length is ${contentLength}B, which is ${actualContentDifference}B larger than requested range of ${contentRange.low}-${contentRange.high}.`);
                     }
 
-                    await this.randomFileAccess.writeStream(targetUrl, contentRange, response.body, totalSize);
+                    const buffer = await streamToBuffer(response.body, contentLength);
+                    await this.randomFileAccess.write(targetUrl, contentRange, buffer, totalSize);
                 });
             }
             yield transferPart;

--- a/lib/functions/transferpartscreate.js
+++ b/lib/functions/transferpartscreate.js
@@ -57,23 +57,24 @@ class CreateTransferParts extends AsyncGeneratorFunction {
         for await (const transferAsset of transferAssets) {
             const contentLength = transferAsset.metadata.contentLength;
             if (transferAsset.acceptRanges && transferAsset.multipartTarget) {
-                const { targetUrls, minPartSize, maxPartSize, headers } = transferAsset.multipartTarget;
+                const { headers: sourceHeaders } = transferAsset.source;
+                const { targetUrls, minPartSize, maxPartSize, headers: targetHeaders } = transferAsset.multipartTarget;
                 const partSize = calculatePartSize(targetUrls.length, contentLength, minPartSize, maxPartSize, this.preferredPartSize);
                 let idx = 0;
                 for (const range of generatePartRanges(contentLength, partSize)) {
-                    yield new TransferPart(transferAsset, [targetUrls[idx]], range, headers);
+                    yield new TransferPart(transferAsset, [targetUrls[idx]], range, sourceHeaders, targetHeaders);
                     ++idx;
                 }   
             } else if (transferAsset.acceptRanges && isFileProtocol(transferAsset.target.url)) {
                 const targetUrls = [transferAsset.target.url];
                 const partSize = this.preferredPartSize || DEFAULT_FILE_TARGET_PART_SIZE;
                 for (const range of generatePartRanges(contentLength, partSize)) {
-                    yield new TransferPart(transferAsset, targetUrls, range);
+                    yield new TransferPart(transferAsset, targetUrls, range, transferAsset.source.headers, transferAsset.target.headers);
                 }
             } else {
                 const targetUrls = [transferAsset.target.url];
                 const contentRange = new DRange(0, contentLength - 1);
-                yield new TransferPart(transferAsset, targetUrls, contentRange, transferAsset.target.headers);
+                yield new TransferPart(transferAsset, targetUrls, contentRange, transferAsset.source.headers, transferAsset.target.headers);
             }
         }
     }

--- a/lib/functions/transferpartscreate.js
+++ b/lib/functions/transferpartscreate.js
@@ -14,6 +14,7 @@
 
 const { AsyncGeneratorFunction } = require("../generator/function");
 const { TransferPart } = require("../asset/transferpart");
+const { TransferEvents } = require("../transfercontroller");
 const { calculatePartSize, generatePartRanges } = require("../aempartsize");
 const { isFileProtocol } = require("../util");
 const DRange = require("drange");
@@ -40,9 +41,11 @@ class CreateTransferParts extends AsyncGeneratorFunction {
      * Construct the CreateTransferParts function.
      * 
      * @param {CreateTransferPartsOptions} [options] Options to split source parts
+     * @param {TransferController} controller Transfer controller
      */
-    constructor(options) {
+    constructor(options, controller) {
         super();
+        this.controller = controller;
         this.preferredPartSize = options && options.preferredPartSize;
     }
 
@@ -57,25 +60,27 @@ class CreateTransferParts extends AsyncGeneratorFunction {
         for await (const transferAsset of transferAssets) {
             const contentLength = transferAsset.metadata.contentLength;
             if (transferAsset.acceptRanges && transferAsset.multipartTarget) {
-                const { headers: sourceHeaders } = transferAsset.source;
                 const { targetUrls, minPartSize, maxPartSize, headers: targetHeaders } = transferAsset.multipartTarget;
                 const partSize = calculatePartSize(targetUrls.length, contentLength, minPartSize, maxPartSize, this.preferredPartSize);
                 let idx = 0;
                 for (const range of generatePartRanges(contentLength, partSize)) {
-                    yield new TransferPart(transferAsset, [targetUrls[idx]], range, sourceHeaders, targetHeaders);
+                    yield new TransferPart(transferAsset, [targetUrls[idx]], range, targetHeaders);
                     ++idx;
                 }   
             } else if (transferAsset.acceptRanges && isFileProtocol(transferAsset.target.url)) {
                 const targetUrls = [transferAsset.target.url];
                 const partSize = this.preferredPartSize || DEFAULT_FILE_TARGET_PART_SIZE;
                 for (const range of generatePartRanges(contentLength, partSize)) {
-                    yield new TransferPart(transferAsset, targetUrls, range, transferAsset.source.headers, transferAsset.target.headers);
+                    yield new TransferPart(transferAsset, targetUrls, range, transferAsset.target.headers);
                 }
             } else {
                 const targetUrls = [transferAsset.target.url];
                 const contentRange = new DRange(0, contentLength - 1);
-                yield new TransferPart(transferAsset, targetUrls, contentRange, transferAsset.source.headers, transferAsset.target.headers);
+                yield new TransferPart(transferAsset, targetUrls, contentRange, transferAsset.target.headers);
             }
+            this.controller.emit(TransferEvents.TRANSFER_START, {
+                transferAsset
+            });
         }
     }
 }

--- a/lib/functions/transferpartsjoin.js
+++ b/lib/functions/transferpartsjoin.js
@@ -63,9 +63,6 @@ class JoinTransferParts extends AsyncGeneratorFunction {
                     completedRanges: new DRange()
                 };
                 this.trackedAssets.set(sourceUrl, trackedAsset);
-                this.controller.emit(TransferEvents.TRANSFER_START, {
-                    transferAsset
-                });
             }
 
             // record progress

--- a/lib/functions/transferpartsjoin.js
+++ b/lib/functions/transferpartsjoin.js
@@ -63,6 +63,9 @@ class JoinTransferParts extends AsyncGeneratorFunction {
                     completedRanges: new DRange()
                 };
                 this.trackedAssets.set(sourceUrl, trackedAsset);
+                this.controller.emit(TransferEvents.TRANSFER_START, {
+                    transferAsset
+                });
             }
 
             // record progress

--- a/lib/index.js
+++ b/lib/index.js
@@ -17,11 +17,13 @@ const { downloadFile, uploadFile } = require('./file');
 const { uploadAEMMultipartFile } = require('./aemmultipart');
 const { getResourceHeaders } = require('./headers');
 const { AEMUpload } = require("./aemupload");
+const { AEMDownload } = require("./aemdownload");
 
 module.exports = {
     downloadStream, uploadStream, transferStream,
     downloadFile, uploadFile,
     uploadAEMMultipartFile,
     getResourceHeaders,
-    AEMUpload
+    AEMUpload,
+    AEMDownload
 };

--- a/lib/randomfileaccess.js
+++ b/lib/randomfileaccess.js
@@ -134,7 +134,7 @@ class RandomFileAccess {
      */
     async write(path, range, buffer, totalSize) {
         const { fileHandles } = this[PRIVATE];
-        const handle = await getOrOpen(fileHandles, path, "w", totalSize);
+        const handle = await getOrOpen(fileHandles, path, FileFlags.WRITEONLY, totalSize);
         return handle.write(buffer, 0, buffer.length, range.low);
     }
 

--- a/lib/randomfileaccess.js
+++ b/lib/randomfileaccess.js
@@ -14,7 +14,6 @@
 
 const PRIVATE = Symbol("PRIVATE");
 const { FileHandle, FileFlags } = require("./filehandle");
-const { streamToBuffer } = require("./util");
 
 /**
  * @typedef {Object} WriteResponse
@@ -137,22 +136,6 @@ class RandomFileAccess {
         const { fileHandles } = this[PRIVATE];
         const handle = await getOrOpen(fileHandles, path, FileFlags.WRITEONLY, totalSize);
         return handle.write(buffer, 0, buffer.length, range.low);
-    }
-
-    /**
-     * Write a section to a file. WARNING: this method will read
-     * the entire contents of the stream into memory; use with
-     * extreme caution.
-     * 
-     * @param {String|URL} path Path of the file to write to
-     * @param {SubRange} range Range of bytes to write
-     * @param {Stream} stream Stream to write.
-     * @param {Number} totalSize Total size of the file written
-     * @returns {WriteResponse} Bytes written and the buffer 
-     */
-    async writeStream(path, range, stream, totalSize) {
-        const buffer = await streamToBuffer(stream);
-        return this.write(path, range, buffer, totalSize);
     }
 
     /**

--- a/lib/randomfileaccess.js
+++ b/lib/randomfileaccess.js
@@ -14,6 +14,7 @@
 
 const PRIVATE = Symbol("PRIVATE");
 const { FileHandle, FileFlags } = require("./filehandle");
+const { streamToBuffer } = require("./util");
 
 /**
  * @typedef {Object} WriteResponse
@@ -136,6 +137,22 @@ class RandomFileAccess {
         const { fileHandles } = this[PRIVATE];
         const handle = await getOrOpen(fileHandles, path, FileFlags.WRITEONLY, totalSize);
         return handle.write(buffer, 0, buffer.length, range.low);
+    }
+
+    /**
+     * Write a section to a file. WARNING: this method will read
+     * the entire contents of the stream into memory; use with
+     * extreme caution.
+     * 
+     * @param {String|URL} path Path of the file to write to
+     * @param {SubRange} range Range of bytes to write
+     * @param {Stream} stream Stream to write.
+     * @param {Number} totalSize Total size of the file written
+     * @returns {WriteResponse} Bytes written and the buffer 
+     */
+    async writeStream(path, range, stream, totalSize) {
+        const buffer = await streamToBuffer(stream);
+        return this.write(path, range, buffer, totalSize);
     }
 
     /**

--- a/lib/transfercontroller.js
+++ b/lib/transfercontroller.js
@@ -61,6 +61,7 @@ const TransferEvents = {
     AFTER_INITIATE_UPLOAD: "afterinitiateupload",
     BEFORE_COMPLETE_UPLOAD: "beforecompleteupload",
     AFTER_COMPLETE_UPLOAD: "aftercompleteupload",
+    TRANSFER_START: "transferstart",
     TRANSFER_PROGRESS: "transferprogress",
     TRANSFER_COMPLETE: "transfercomplete"
 };

--- a/lib/util.js
+++ b/lib/util.js
@@ -102,23 +102,30 @@ function isValidNumber(value) {
  * the stream into memory; use with extreme caution.
  *
  * @param {ReadableStream} stream Stream to convert.
+ * @param {number} totalSize Total size of the stream.
  * @returns {Promise<Buffer>} Contents of the stream in a
  *  Buffer.
  */
-async function streamToBuffer(stream) {
+async function streamToBuffer(stream, totalSize) {
     return new Promise((resolve, reject) => {
-        const chunks = [];
+        const buffer = Buffer.allocUnsafe(totalSize);
+        let bufferOffset = 0;
 
         stream.once('error', (err) => {
             reject(err);
         });
 
         stream.once('end', () => {
-            resolve(Buffer.concat(chunks));
+            if (bufferOffset !== totalSize) {
+                reject(`Unexpected number of bytes read from stream. Expected ${totalSize} but got ${bufferOffset}.`);
+                return;
+            }
+            resolve(buffer);
         });
 
         stream.on('data', (chunk) => {
-            chunks.push(chunk);
+            chunk.copy(buffer, bufferOffset, 0);
+            bufferOffset += chunk.length;
         });
     });
 }

--- a/lib/util.js
+++ b/lib/util.js
@@ -96,10 +96,38 @@ function isValidNumber(value) {
     return (typeof value === "number") && !isNaN(value);
 }
 
+/**
+ * Converts the content of a readable Stream into a Buffer
+ * instance. WARNING: this method will read the entirety of
+ * the stream into memory; use with extreme caution.
+ *
+ * @param {ReadableStream} stream Stream to convert.
+ * @returns {Promise<Buffer>} Contents of the stream in a
+ *  Buffer.
+ */
+async function streamToBuffer(stream) {
+    return new Promise((resolve, reject) => {
+        const chunks = [];
+
+        stream.once('error', (err) => {
+            reject(err);
+        });
+
+        stream.once('end', () => {
+            resolve(Buffer.concat(chunks));
+        });
+
+        stream.on('data', (chunk) => {
+            chunks.push(chunk);
+        });
+    });
+}
+
 module.exports = {
     getFileStats,
     createReadStream,
     createWriteStream,
     isFileProtocol,
-    isValidNumber
+    isValidNumber,
+    streamToBuffer
 };

--- a/test/aemdownload.test.js
+++ b/test/aemdownload.test.js
@@ -29,12 +29,12 @@ describe('AEM Download', function() {
     it('AEM download smoke test', async function() {
         const testFile = Path.join(__dirname, 'file-1.jpg');
         nock('http://test-aem-download-200')
-            .matchHeader('content-range', 'bytes 0-6/12')
+            .matchHeader('range', 'bytes=0-6')
             .get('/path/to/file-1.jpg')
             .reply(200, 'Hello W');
 
         nock('http://test-aem-download-200')
-            .matchHeader('content-range', 'bytes 7-11/12')
+            .matchHeader('range', 'bytes=7-11')
             .get('/path/to/file-1.jpg')
             .reply(200, 'orld!');
 
@@ -79,8 +79,8 @@ describe('AEM Download', function() {
         const fileEventData = {
             fileName: 'file-1.jpg',
             fileSize: 12,
-            targetFolder: '/Users/frisbey/projects/node-httptransfer/test',
-            targetFile: '/Users/frisbey/projects/node-httptransfer/test/file-1.jpg'
+            targetFolder: __dirname,
+            targetFile: testFile
         };
 
         assert.deepEqual(events.filestart[0], fileEventData);

--- a/test/aemdownload.test.js
+++ b/test/aemdownload.test.js
@@ -1,0 +1,97 @@
+/*
+ * Copyright 2021 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+/* eslint-env mocha */
+
+'use strict';
+
+const assert = require('assert');
+const fs = require('fs').promises;
+const nock = require('nock');
+const Path = require('path');
+const { AEMDownload } = require('../lib/aemdownload');
+
+describe('AEM Download', function() {
+    afterEach(async function () {
+        assert.ok(nock.isDone(), 'check if all nocks have been used');
+        nock.cleanAll();
+    });
+
+    it('AEM download smoke test', async function() {
+        const testFile = Path.join(__dirname, 'file-1.jpg');
+        nock('http://test-aem-download-200')
+            .matchHeader('content-range', 'bytes 0-6/12')
+            .get('/path/to/file-1.jpg')
+            .reply(200, 'Hello W');
+
+        nock('http://test-aem-download-200')
+            .matchHeader('content-range', 'bytes 7-11/12')
+            .get('/path/to/file-1.jpg')
+            .reply(200, 'orld!');
+
+        const aemDownload = new AEMDownload();
+        const events = {
+            filestart: [],
+            fileprogress:[],
+            fileend: []
+        };
+        aemDownload.on('filestart', (data) => {
+            events.filestart.push(data);
+        });
+        aemDownload.on('fileprogress', (data) => {
+            events.fileprogress.push(data);
+        });
+        aemDownload.on('fileend', (data) => {
+            events.fileend.push(data);
+        });
+        await aemDownload.downloadFiles({
+            downloadFiles: [{
+                fileUrl: 'http://test-aem-download-200/path/to/file-1.jpg',
+                filePath: testFile,
+                fileSize: 12
+            }],
+            headers: {},
+            concurrent: true,
+            maxConcurrent: 5,
+            preferredPartSize: 7
+        });
+        const fileData = await fs.readFile(testFile);
+
+        try {
+            await fs.unlink(testFile);
+        } catch (e) { // ignore cleanup failures
+            console.log(e);
+        }
+        assert.equal(fileData.toString(), 'Hello World!');
+        assert.equal(events.filestart.length, 1);
+        assert.equal(events.fileprogress.length, 2);
+        assert.equal(events.fileend.length, 1);
+
+        const fileEventData = {
+            fileName: 'file-1.jpg',
+            fileSize: 12,
+            targetFolder: '/Users/frisbey/projects/node-httptransfer/test',
+            targetFile: '/Users/frisbey/projects/node-httptransfer/test/file-1.jpg'
+        };
+
+        assert.deepEqual(events.filestart[0], fileEventData);
+        assert.deepEqual(events.fileprogress[0], {
+            ...fileEventData,
+            transferred: 7
+        });
+        assert.deepEqual(events.fileprogress[1], {
+            ...fileEventData,
+            transferred: 12
+        });
+        assert.deepEqual(events.fileend[0], fileEventData);
+    });
+});

--- a/test/util.test.js
+++ b/test/util.test.js
@@ -18,6 +18,7 @@ const assert = require("assert");
 const util = require("../lib/util");
 const fs = require('fs').promises;
 const path = require('path');
+const { EventEmitter } = require("events");
 
 describe("util", function() {
     it("createReadStream-error", async function() {
@@ -86,5 +87,38 @@ describe("util", function() {
     });
     it('file-protocol-url-http', function() {
         assert.ok(!util.isFileProtocol(new URL('http://www.host.com')));
+    });
+    function configureStream(toExecute) {
+        const stream = new EventEmitter();
+        const origOn = stream.on;
+        stream.on = (name, data) => {
+            origOn.call(stream, name, data);
+            if (name === 'data') {
+                toExecute(stream);
+            }
+        };
+        return stream;
+    }
+    it('stream-to-buffer', async function() {
+        const stream = configureStream((stream) => {
+            stream.emit('data', Buffer.from('Hello W'));
+            stream.emit('data', Buffer.from('orld!'));
+            stream.emit('end');
+        });
+        const buffer = await util.streamToBuffer(stream, 12);
+        assert.deepEqual(buffer.toString(), 'Hello World!');
+    });
+    it('stream-to-error-buffer', function() {
+        const stream = configureStream((stream) => {
+            stream.emit('error', 'there was an error!');
+        });
+        assert.rejects(util.streamToBuffer(stream, 12));
+    });
+    it('stream-to-unexpectedlength-buffer', function() {
+        const stream = configureStream((stream) => {
+            stream.emit('data', 'test');
+            stream.emit('end');
+        });
+        assert.rejects(util.streamToBuffer(stream, 12));
     });
 });


### PR DESCRIPTION
## Description

The PR introduces `AEMDownload`, which is similar to `AEMUpload`, but in reverse. It allows fast transferring of files from a remote URL to a local file. It utilizes the HTTP `Content-Range` header to request parts of a remote file, which the module will concurrently transfer to a local file.

Open questions:

* Due to usage of `fs.write()` when writing parts to a local file, I had to convert the `Stream` provided in an HTTP response to a `Buffer` so it could be used with `fs.write()`. This reads the entirety of each `Stream` into memory. This is a risk to the amount of RAM the module will use while transferring files. However, since each chunk is (hopefully) small, and the number of concurrent threads is limited, this should reduce the risk. I also added a safety check to ensure that an entire file isn't read into memory if the server responds with the full file instead of only the requested part. Any thoughts or suggestions here?

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- ~[ ] My change requires a change to the documentation.~
- ~[ ] I have updated the documentation accordingly.~
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
