### PR TITLE
ensure file events contain valid windows paths.

### DIFF
--- a/lib/asset/transferasset.js
+++ b/lib/asset/transferasset.js
@@ -21,6 +21,7 @@ const { AssetVersion } = require("./assetversion");
 const { NameConflictPolicy } = require("./nameconflictpolicy");
 const { MIMETYPE } = require("../constants");
 const { IllegalArgumentError } = require("../error");
+const { urlToPath } = require("../util");
 
 const PRIVATE = Symbol("PRIVATE");
 
@@ -199,13 +200,15 @@ class TransferAsset {
      * @returns {*} File event data.
      */
     get eventData() {
+        const sourcePath = urlToPath(this.source.url.href);
+        const targetPath = urlToPath(this.target.url.href);
         const data = {
-            fileName: decodeURI(urlPathBasename(this.target.url.pathname)),
+            fileName: urlPathBasename(targetPath),
             fileSize: this.metadata && this.metadata.contentLength,
-            targetFolder: decodeURI(urlPathDirname(this.target.url.pathname)),
-            targetFile: decodeURI(this.target.url.pathname),
-            sourceFolder: decodeURI(urlPathDirname(this.source.url.pathname)),
-            sourceFile: decodeURI(this.source.url.pathname),
+            targetFolder: urlPathDirname(targetPath),
+            targetFile: targetPath,
+            sourceFolder: urlPathDirname(sourcePath),
+            sourceFile: sourcePath,
         };
 
         if (this.metadata && this.metadata.contentType) {

--- a/lib/asset/transferasset.js
+++ b/lib/asset/transferasset.js
@@ -12,8 +12,6 @@
 
 "use strict";
 
-const { dirname: urlPathDirname, basename: urlPathBasename } = require("path").posix;
-
 const { Asset } = require("./asset");
 const { AssetMetadata } = require("./assetmetadata");
 const { AssetMultipart } = require("./assetmultipart");
@@ -203,12 +201,12 @@ class TransferAsset {
         const sourcePath = urlToPath(this.source.url.href);
         const targetPath = urlToPath(this.target.url.href);
         const data = {
-            fileName: urlPathBasename(targetPath),
+            fileName: targetPath.name,
             fileSize: this.metadata && this.metadata.contentLength,
-            targetFolder: urlPathDirname(targetPath),
-            targetFile: targetPath,
-            sourceFolder: urlPathDirname(sourcePath),
-            sourceFile: sourcePath,
+            targetFolder: targetPath.parentPath,
+            targetFile: targetPath.path,
+            sourceFolder: sourcePath.parentPath,
+            sourceFile: sourcePath.path,
         };
 
         if (this.metadata && this.metadata.contentType) {

--- a/lib/filehandle.js
+++ b/lib/filehandle.js
@@ -68,7 +68,7 @@ class FileHandle {
      */
     static async open(path, flags) {
         return new Promise((resolve, reject) => {
-            const filePath = urlToPath(path);
+            const filePath = urlToPath(path).path;
             const openFlags = (flags === FileFlags.WRITEONLY) ? "w" : "r";
             fs.open(filePath, openFlags, (err, fd) => {
                 if (err) {

--- a/lib/filehandle.js
+++ b/lib/filehandle.js
@@ -16,7 +16,7 @@ require("core-js/stable");
 
 const fs = require("fs");
 const logger = require("./logger");
-const { fileUrlToFilePath } = require("./util");
+const { urlToPath } = require("./util");
 
 /**
  * File open flags
@@ -68,7 +68,7 @@ class FileHandle {
      */
     static async open(path, flags) {
         return new Promise((resolve, reject) => {
-            const filePath = fileUrlToFilePath(path);
+            const filePath = urlToPath(path);
             const openFlags = (flags === FileFlags.WRITEONLY) ? "w" : "r";
             fs.open(filePath, openFlags, (err, fd) => {
                 if (err) {

--- a/lib/util.js
+++ b/lib/util.js
@@ -14,6 +14,7 @@
 
 require("core-js/stable");
 
+const { sep } = require('path');
 const fs = require('fs');
 const validUrl = require('valid-url');
 const { HttpStreamError } = require("./error");
@@ -152,28 +153,37 @@ async function streamToBuffer(method, url, status, stream, totalSize) {
 }
 
 /**
- * Converts one of several potential values to a local file path.
- * If the value is a string and does _not_ begin with "file://", then
- * the value will be returned as-is. Otherwise the value is assumed to
- * be a file URL, and the method will return the local path represented
- * by the URL.
+ * Converts one of several potential URL values to its path.
+ *
+ * For example:
+ *
+ * If the value is a file URL (i.e. begins with file://), then the method
+ * will return the URL's pathname. The method takes into account windows-style
+ * paths, which might be preceeded with a leading forward slash. In addition,
+ * the path will have the correct path separators, depending on the operating
+ * system (i.e. backslash for windows, forward slash for posix). The path
+ * will have also been URI decoded.
+ *
+ * Otherwise the value is assumed to be an HTTP URL, and the URL's URI decoded
+ * pathname is returned.
  * @param {URL|string} path Value whose path should be retrieved.
  * @returns {string} A local file path.
  */
-function fileUrlToFilePath(path) {
-    if ((typeof path === "string") && !path.startsWith("file://")) {
-        return path;
-    } else {
-        const url = new URL(path);
-        let filePath = decodeURIComponent(url.pathname);
+function urlToPath(path) {
+    const url = new URL(path);
+    let urlPath = decodeURIComponent(url.pathname);
+
+    if (url.protocol === "file:") {
         // windows paths will have a forward slash followed by
         // the drive letter. strip off the leading forward slash
         // if it appears to be a windows path (i.e. starts with "/C:/")
-        if (/^\/[a-zA-Z]:\//g.exec(filePath)) {
-            filePath = filePath.substr(1);
+        if (/^\/[a-zA-Z]:\//g.exec(urlPath)) {
+            urlPath = urlPath.substr(1);
         }
-        return filePath;
+        urlPath = urlPath.replace(/\//g, sep);
     }
+
+    return urlPath;
 }
 
 module.exports = {
@@ -184,5 +194,5 @@ module.exports = {
     isFileProtocol,
     isPositiveNumber,
     streamToBuffer,
-    fileUrlToFilePath
+    urlToPath,
 };

--- a/lib/util.js
+++ b/lib/util.js
@@ -14,7 +14,8 @@
 
 require("core-js/stable");
 
-const { sep } = require('path');
+const { sep, dirname: filePathDirname, basename: filePathBasename } = require('path');
+const { dirname: urlPathDirname, basename: urlPathBasename } = require("path").posix;
 const fs = require('fs');
 const validUrl = require('valid-url');
 const { HttpStreamError } = require("./error");
@@ -153,6 +154,11 @@ async function streamToBuffer(method, url, status, stream, totalSize) {
 }
 
 /**
+ * @typedef {Object} PathInformation Information about the URL's path.
+ * @property {string} path Full path from the URL.
+ * @property {string} name Name of the item from the URL's path.
+ * @property {string} parentPath Full path of the item's parent.
+ *
  * Converts one of several potential URL values to its path.
  *
  * For example:
@@ -167,11 +173,13 @@ async function streamToBuffer(method, url, status, stream, totalSize) {
  * Otherwise the value is assumed to be an HTTP URL, and the URL's URI decoded
  * pathname is returned.
  * @param {URL|string} path Value whose path should be retrieved.
- * @returns {string} A local file path.
+ * @returns {PathInformation} Information about the URL's path.
  */
 function urlToPath(path) {
     const url = new URL(path);
     let urlPath = decodeURIComponent(url.pathname);
+    let parentPath = urlPathDirname(urlPath);
+    let name = urlPathBasename(urlPath);
 
     if (url.protocol === "file:") {
         // windows paths will have a forward slash followed by
@@ -181,9 +189,15 @@ function urlToPath(path) {
             urlPath = urlPath.substr(1);
         }
         urlPath = urlPath.replace(/\//g, sep);
+        parentPath = filePathDirname(urlPath);
+        name = filePathBasename(urlPath);
     }
 
-    return urlPath;
+    return {
+        path: urlPath,
+        name,
+        parentPath,
+    };
 }
 
 module.exports = {

--- a/test/asset/transferasset.test.js
+++ b/test/asset/transferasset.test.js
@@ -23,6 +23,10 @@ const { AssetVersion } = require('../../lib/asset/assetversion');
 const { NameConflictPolicy } = require('../../lib/asset/nameconflictpolicy');
 const { TransferAsset } = require('../../lib/asset/transferasset');
 
+function getExpectedFilePath(path) {
+    return path.replace(/\//g, sep);
+}
+
 describe("TransferAsset", function() {
     describe("constructor", () => {
         it("no-source no-target fail", () => {
@@ -61,8 +65,8 @@ describe("TransferAsset", function() {
                 fileSize: undefined,
                 sourceFile: '/path/to/source.png',
                 sourceFolder: '/path/to',
-                targetFile: "/path/to/target.png",
-                targetFolder: "/path/to"
+                targetFile: getExpectedFilePath("/path/to/target.png"),
+                targetFolder: getExpectedFilePath("/path/to")
             });
         });
         it("upload", () => {
@@ -79,8 +83,8 @@ describe("TransferAsset", function() {
             assert.deepStrictEqual(transferAsset.eventData, {
                 fileName: "target.png",
                 fileSize: undefined,
-                sourceFile: '/path/to/source.png',
-                sourceFolder: '/path/to',
+                sourceFile: getExpectedFilePath('/path/to/source.png'),
+                sourceFolder: getExpectedFilePath('/path/to'),
                 targetFile: "/path/to/target.png",
                 targetFolder: "/path/to"
             });
@@ -105,8 +109,8 @@ describe("TransferAsset", function() {
                 fileName: "target.png",
                 fileSize: 9876,
                 mimeType: "image/png",
-                sourceFile: '/path/to/source.png',
-                sourceFolder: '/path/to',
+                sourceFile: getExpectedFilePath('/path/to/source.png'),
+                sourceFolder: getExpectedFilePath('/path/to'),
                 targetFile: "/path/to/target.png",
                 targetFolder: "/path/to"
             });
@@ -139,8 +143,8 @@ describe("TransferAsset", function() {
                 fileName: "target.png",
                 fileSize: 9876,
                 mimeType: "image/png",
-                sourceFile: '/path/to/source.png',
-                sourceFolder: '/path/to',
+                sourceFile: getExpectedFilePath('/path/to/source.png'),
+                sourceFolder: getExpectedFilePath('/path/to'),
                 targetFile: "/path/to/target.png",
                 targetFolder: "/path/to"
             });
@@ -171,8 +175,8 @@ describe("TransferAsset", function() {
             assert.deepStrictEqual(transferAsset.eventData, {
                 fileName: "target.png",
                 fileSize: undefined,
-                sourceFile: '/path/to/source.png',
-                sourceFolder: '/path/to',
+                sourceFile: getExpectedFilePath('/path/to/source.png'),
+                sourceFolder: getExpectedFilePath('/path/to'),
                 targetFile: "/path/to/target.png",
                 targetFolder: "/path/to"
             });
@@ -193,8 +197,8 @@ describe("TransferAsset", function() {
             assert.deepStrictEqual(transferAsset.eventData, {
                 fileName: "target.png",
                 fileSize: undefined,
-                sourceFile: '/path/to/source.png',
-                sourceFolder: '/path/to',
+                sourceFile: getExpectedFilePath('/path/to/source.png'),
+                sourceFolder: getExpectedFilePath('/path/to'),
                 targetFile: "/path/to/target.png",
                 targetFolder: "/path/to"
             });
@@ -215,8 +219,8 @@ describe("TransferAsset", function() {
             assert.deepStrictEqual(transferAsset.eventData, {
                 fileName: "target.png",
                 fileSize: undefined,
-                sourceFile: '/path/to/source.png',
-                sourceFolder: '/path/to',
+                sourceFile: getExpectedFilePath('/path/to/source.png'),
+                sourceFolder: getExpectedFilePath('/path/to'),
                 targetFile: "/path/to/target.png",
                 targetFolder: "/path/to"
             });
@@ -237,8 +241,8 @@ describe("TransferAsset", function() {
             assert.deepStrictEqual(transferAsset.eventData, {
                 fileName: "target.png",
                 fileSize: undefined,
-                sourceFile: '/path/to/source.png',
-                sourceFolder: '/path/to',
+                sourceFile: getExpectedFilePath('/path/to/source.png'),
+                sourceFolder: getExpectedFilePath('/path/to'),
                 targetFile: "/path/to/target.png",
                 targetFolder: "/path/to"
             });
@@ -262,8 +266,8 @@ describe("TransferAsset", function() {
             assert.deepStrictEqual(transferAsset.eventData, {
                 fileName: "target.png",
                 fileSize: undefined,
-                sourceFile: '/path/to/source.png',
-                sourceFolder: '/path/to',
+                sourceFile: getExpectedFilePath('/path/to/source.png'),
+                sourceFolder: getExpectedFilePath('/path/to'),
                 targetFile: "/path/to/target.png",
                 targetFolder: "/path/to"
             });
@@ -295,8 +299,8 @@ describe("TransferAsset", function() {
             assert.deepStrictEqual(transferAsset.eventData, {
                 fileName: "target.png",
                 fileSize: undefined,
-                sourceFile: '/path/to/source.png',
-                sourceFolder: '/path/to',
+                sourceFile: getExpectedFilePath('/path/to/source.png'),
+                sourceFolder: getExpectedFilePath('/path/to'),
                 targetFile: "/path/to/target.png",
                 targetFolder: "/path/to"
             });
@@ -328,8 +332,8 @@ describe("TransferAsset", function() {
             assert.deepStrictEqual(transferAsset.eventData, {
                 fileName: "target.png",
                 fileSize: undefined,
-                sourceFile: '/path/to/source.png',
-                sourceFolder: '/path/to',
+                sourceFile: getExpectedFilePath('/path/to/source.png'),
+                sourceFolder: getExpectedFilePath('/path/to'),
                 targetFile: "/path/to/target.png",
                 targetFolder: "/path/to"
             });
@@ -361,8 +365,8 @@ describe("TransferAsset", function() {
             assert.deepStrictEqual(transferAsset.eventData, {
                 fileName: "target.png",
                 fileSize: undefined,
-                sourceFile: '/path/to/source.png',
-                sourceFolder: '/path/to',
+                sourceFile: getExpectedFilePath('/path/to/source.png'),
+                sourceFolder: getExpectedFilePath('/path/to'),
                 targetFile: "/path/to/target.png",
                 targetFolder: "/path/to"
             });
@@ -394,8 +398,8 @@ describe("TransferAsset", function() {
             assert.deepStrictEqual(transferAsset.eventData, {
                 fileName: "target.png",
                 fileSize: undefined,
-                sourceFile: '/path/to/source.png',
-                sourceFolder: '/path/to',
+                sourceFile: getExpectedFilePath('/path/to/source.png'),
+                sourceFolder: getExpectedFilePath('/path/to'),
                 targetFile: "/path/to/target.png",
                 targetFolder: "/path/to"
             });
@@ -427,8 +431,8 @@ describe("TransferAsset", function() {
             assert.deepStrictEqual(transferAsset.eventData, {
                 fileName: "target.png",
                 fileSize: undefined,
-                sourceFile: '/path/to/source.png',
-                sourceFolder: '/path/to',
+                sourceFile: getExpectedFilePath('/path/to/source.png'),
+                sourceFolder: getExpectedFilePath('/path/to'),
                 targetFile: "/path/to/target.png",
                 targetFolder: "/path/to"
             });
@@ -453,8 +457,8 @@ describe("TransferAsset", function() {
                 mimeType: "image/png",
                 targetFolder: "/path/to",
                 targetFile: "/path/to/target.png",
-                sourceFolder: `C:${sep}path${sep}to`,
-                sourceFile: `C:${sep}path${sep}to${sep}source.png`,
+                sourceFolder: getExpectedFilePath('C:/path/to'),
+                sourceFile: getExpectedFilePath('C:/path/to/source.png'),
             });
         });
     });

--- a/test/asset/transferasset.test.js
+++ b/test/asset/transferasset.test.js
@@ -15,6 +15,7 @@
 'use strict';
 
 const assert = require('assert');
+const { sep } = require('path');
 const { Asset } = require('../../lib/asset/asset');
 const { AssetMetadata } = require('../../lib/asset/assetmetadata');
 const { AssetMultipart } = require('../../lib/asset/assetmultipart');
@@ -439,6 +440,22 @@ describe("TransferAsset", function() {
                 const transferAsset = new TransferAsset(source, target);
                 transferAsset.nameConflictPolicy = 123;    
             }, Error("'nameConflictPolicy' must be of type NameConflictPolicy: 123 (number)"));
+        });
+        it("test event data with windows paths", () => {
+            const source = new Asset("file:///C:/path/to/source.png");
+            const target = new Asset("http://host/path/to/target.png");
+            const transferAsset = new TransferAsset(source, target, {
+                metadata: new AssetMetadata("source.png", "image/png", 100),
+            });
+            assert.deepStrictEqual(transferAsset.eventData, {
+                fileName: "target.png",
+                fileSize: 100,
+                mimeType: "image/png",
+                targetFolder: "/path/to",
+                targetFile: "/path/to/target.png",
+                sourceFolder: `C:${sep}path${sep}to`,
+                sourceFile: `C:${sep}path${sep}to${sep}source.png`,
+            });
         });
     });
 });

--- a/test/util.test.js
+++ b/test/util.test.js
@@ -124,8 +124,20 @@ describe("util", function() {
     });
 
     it('url to path', function() {
-        assert.strictEqual(util.urlToPath('http://host/test%20space/path'), '/test space/path');
-        assert.strictEqual(util.urlToPath('file:///test%20space/path'), `${path.sep}test space${path.sep}path`);
-        assert.strictEqual(util.urlToPath('file:///C:/test%20space/path'), `C:${path.sep}test space${path.sep}path`);
+        assert.deepStrictEqual(util.urlToPath('http://host/test%20space/path'), {
+            path: '/test space/path',
+            name: 'path',
+            parentPath: '/test space',
+        });
+        assert.deepStrictEqual(util.urlToPath('file:///test%20space/path'), {
+            path: `${path.sep}test space${path.sep}path`,
+            name: 'path',
+            parentPath: `${path.sep}test space`,
+        });
+        assert.deepStrictEqual(util.urlToPath('file:///C:/test%20space/path'), {
+            path: `C:${path.sep}test space${path.sep}path`,
+            name: 'path',
+            parentPath: `C:${path.sep}test space`,
+        });
     });
 });

--- a/test/util.test.js
+++ b/test/util.test.js
@@ -123,9 +123,9 @@ describe("util", function() {
         assert.rejects(util.streamToBuffer("get", "url", 200, stream, 12));
     });
 
-    it('file url to file path', function() {
-        assert.strictEqual(util.fileUrlToFilePath('/test/path'), '/test/path');
-        assert.strictEqual(util.fileUrlToFilePath('file:///test/path'), '/test/path');
-        assert.strictEqual(util.fileUrlToFilePath('file:///C:/test/path'), 'C:/test/path');
+    it('url to path', function() {
+        assert.strictEqual(util.urlToPath('http://host/test%20space/path'), '/test space/path');
+        assert.strictEqual(util.urlToPath('file:///test%20space/path'), `${path.sep}test space${path.sep}path`);
+        assert.strictEqual(util.urlToPath('file:///C:/test%20space/path'), `C:${path.sep}test space${path.sep}path`);
     });
 });


### PR DESCRIPTION
## Description

When working with Windows-style paths, the library was not providing valid paths in its file events. For example, when downloading a file the `filestart` event would look similar to the following:

```
{
  fileName: 'my-asset.jpg',
  fileSize: 100,
  mimeType: 'image/jpeg',
  targetFolder: '/C:/Users/someuser',
  targetFile: '/C:/Users/someuser/my-asset.jpg',
  sourceFolder: '/content/dam',
  sourceFile: '/content/dam/my-asset.jpg',
}
```

Note the preceding forward slash, and the incorrect path separators. After this fix the event data will look as follows:

```
{
  fileName: 'my-asset.jpg',
  fileSize: 100,
  mimeType: 'image/jpeg',
  targetFolder: 'C:\Users\someuser',
  targetFile: 'C:\Users\someuser\my-asset.jpg',
  sourceFolder: '/content/dam',
  sourceFile: '/content/dam/my-asset.jpg',
}
```

Note the correct local paths, with correct separators and drive letter.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
