### PR TITLE
Add retryMaxCount, overrides retryMaxDuration if provided

### DIFF
--- a/lib/aem/aemdownload.js
+++ b/lib/aem/aemdownload.js
@@ -99,12 +99,16 @@ class AEMDownload extends EventEmitter {
             }
         });
 
+        const retryOptions = {
+            retryMaxCount: 5
+        };
+
         // Build and execute pipeline
         const randomFileAccess = new RandomFileAccess();
         try {
             const pipeline = new Pipeline(
                 new CreateTransferParts({ preferredPartSize }),
-                new MapConcurrent(new Transfer(randomFileAccess), { maxConcurrent }),
+                new MapConcurrent(new Transfer(randomFileAccess, retryOptions), { maxConcurrent }),
                 new JoinTransferParts,
                 new CloseFiles(randomFileAccess),
             );

--- a/lib/aem/aemupload.js
+++ b/lib/aem/aemupload.js
@@ -115,18 +115,22 @@ class AEMUpload extends EventEmitter {
                 });
             }
         });
+
+        const retryOptions = {
+            retryMaxCount: 5
+        };
         
         // Build and execute pipeline
         const randomFileAccess = new RandomFileAccess();
         try {
             const pipeline = new Pipeline(
                 new FailUnsupportedAssets(),
-                new MapConcurrent(new AEMInitiateUpload, { maxBatchLength: 100 }),
+                new MapConcurrent(new AEMInitiateUpload(retryOptions), { maxBatchLength: 100 }),
                 new CreateTransferParts({ preferredPartSize }),
-                new MapConcurrent(new Transfer(randomFileAccess), { maxConcurrent }),
+                new MapConcurrent(new Transfer(randomFileAccess, retryOptions), { maxConcurrent }),
                 new JoinTransferParts,
                 new CloseFiles(randomFileAccess),
-                new MapConcurrent(new AEMCompleteUpload),
+                new MapConcurrent(new AEMCompleteUpload(retryOptions)),
             );
             pipeline.setFilterFunction(new FilterFailedAssets);
             await executePipeline(pipeline, generateAEMUploadTransferRecords(options), controller);

--- a/lib/functions/aemcompleteupload.js
+++ b/lib/functions/aemcompleteupload.js
@@ -21,8 +21,9 @@ const { retry } = require("../retry");
 
 /**
  * @typedef {Object} AEMCompleteUploadOptions
- * @property {Number} [timeout] Socket timeout
- * @property {Number} [retryMax=60000] time to retry until throwing an error (ms)
+ * @property {Number} [timeout=30000] Socket timeout
+ * @property {Number} [retryMaxCount] number of retry attempts, overrides retryMaxDuration
+ * @property {Number} [retryMaxDuration=60000] time to retry until throwing an error (ms)
  * @property {Number} [retryInterval=100] time between retries, used by exponential backoff (ms)
  * @property {Boolean} [retryEnabled=true] retry on failure enabled
  * @property {Boolean} [retryAllErrors=false] whether or not to retry on all http error codes or just >=500

--- a/lib/functions/aeminitiateupload.js
+++ b/lib/functions/aeminitiateupload.js
@@ -23,8 +23,9 @@ const { TransferEvents } = require("../controller/transfercontroller");
 
 /**
  * @typedef {Object} AEMInitiateUploadOptions
- * @property {Number} [timeout] Socket timeout
- * @property {Number} [retryMax=60000] time to retry until throwing an error (ms)
+ * @property {Number} [timeout=30000] Socket timeout
+ * @property {Number} [retryMaxCount] number of retry attempts, overrides retryMaxDuration
+ * @property {Number} [retryMaxDuration=60000] time to retry until throwing an error (ms)
  * @property {Number} [retryInterval=100] time between retries, used by exponential backoff (ms)
  * @property {Boolean} [retryEnabled=true] retry on failure enabled
  * @property {Boolean} [retryAllErrors=false] whether or not to retry on all http error codes or just >=500

--- a/lib/functions/getassetmetadata.js
+++ b/lib/functions/getassetmetadata.js
@@ -23,8 +23,9 @@ const { TransferEvents } = require("../controller/transfercontroller");
 
 /**
  * @typedef {Object} GetAssetMetadataOptions
- * @property {Number} [timeout] Socket timeout
- * @property {Number} [retryMax=60000] time to retry until throwing an error (ms)
+ * @property {Number} [timeout=30000] Socket timeout
+ * @property {Number} [retryMaxCount] number of retry attempts, overrides retryMaxDuration
+ * @property {Number} [retryMaxDuration=60000] time to retry until throwing an error (ms)
  * @property {Number} [retryInterval=100] time between retries, used by exponential backoff (ms)
  * @property {Boolean} [retryEnabled=true] retry on failure enabled
  * @property {Boolean} [retryAllErrors=false] whether or not to retry on all http error codes or just >=500

--- a/lib/functions/transfer.js
+++ b/lib/functions/transfer.js
@@ -24,8 +24,9 @@ const MAX_MEMORY_BUFFER = 100*1024*1024;
 /**
  * @typedef {Object} TransferOptions
  *
- * @property {Number} [timeout] Optional socket timeout
- * @property {Number} [retryMax=60000] time to retry until throwing an error (ms)
+ * @property {Number} [timeout=3000] Optional socket timeout
+ * @property {Number} [retryMaxCount] number of retry attempts, overrides retryMaxDuration
+ * @property {Number} [retryMaxDuration=60000] time to retry until throwing an error (ms)
  * @property {Number} [retryInterval=100] time between retries, used by exponential backoff (ms)
  * @property {Boolean} [retryEnabled=true] retry on failure enabled
  * @property {Boolean} [retryAllErrors=false] whether or not to retry on all http error codes or just >=500
@@ -115,7 +116,7 @@ class Transfer extends AsyncGeneratorFunction {
             
                         const buffer = await streamToBuffer(HTTP.METHOD.GET, transferPart.source.url, response.status, response.body, contentLength);
                         await this.randomFileAccess.write(targetUrl, contentRange, buffer, totalSize);
-                    });
+                    }, this.options);
                 }
 
                 controller.notify(TransferEvents.AFTER_TRANSFER, this.name, transferPart);

--- a/lib/retry.js
+++ b/lib/retry.js
@@ -19,6 +19,7 @@ const { HttpConnectError, HttpStreamError, HttpResponseError } = require("./erro
 /**
  * @typedef {Object} RetryOptions
  * @property {Date} startTime start time using `Date.now()`
+ * @property {Number} [retryMaxCount] number of retry attempts, overrides retryMaxDuration
  * @property {Number} retryMaxDuration time to retry until throwing an error
  * @property {Number} retryInitialDelay time between retries, used by exponential backoff (ms)
  * @property {Number} retryBackoff backoff factor for wait time between retries (defaults to 2.0)
@@ -55,6 +56,7 @@ function retryInit(options={}) {
 
         return {
             startTime: Date.now(),
+            retryMaxCount: options.retryMaxCount,
             retryMaxDuration: retryMaxDuration,
             retryInitialDelay: options.retryInitialDelay || DEFAULT_INITIAL_WAIT,
             retryBackoff: options.retryBackoff || DEFAULT_BACKOFF,
@@ -75,6 +77,7 @@ function retryInit(options={}) {
 function filterOptions(options) {
     return options && filterObject(options, key => [
         "retryEnabled",
+        "retryMaxCount",
         "retryMaxDuration",
         "retryInitialDelay",
         "retryAllErrors",
@@ -87,24 +90,33 @@ function filterOptions(options) {
  * Calculate the retry delay
  *
  * @param {Integer} interval Min time to wait for retry
- * @param {Boolean} [random=true] Add randomness
  */
-function retryDelay(interval, random = true) {
-    return interval +
-        (random ? Math.floor(Math.random() * 100) : 99);
+function retryDelay(interval) {
+    return interval + Math.floor(Math.random() * 100);
 }
 
 /**
  * Check whether a given error requires retry
  *
+ * @param {Number} attempt Number of attempts
  * @param {Error} error Error to analyze
  * @param {RetryOptions} options Retry options
+ * @returns {Boolean} True if the request should be retried
  */
-function retryOn(error, options) {
+function retryOn(attempt, error, options) {
     if (options) {
-        const waited = Date.now() - options.startTime;
-        const toWait = retryDelay(options.retryInitialDelay) + waited;
-        return (toWait < options.retryMaxDuration) && (
+        if (options.retryMaxCount) {
+            if (attempt >= options.retryMaxCount) {
+                return false; 
+            }
+        } else {
+            const waited = Date.now() - options.startTime;
+            const toWait = retryDelay(options.retryInitialDelay) + waited;
+            if (toWait >= options.retryMaxDuration) {
+                return false;
+            }
+        }
+        return (
             (error instanceof HttpConnectError) ||
             (error instanceof HttpStreamError) ||
             ((error instanceof HttpResponseError) &&
@@ -132,7 +144,7 @@ async function retryInvoke(asyncFunc, options, retryOpts) {
                 }
                 return resolve(await asyncFunc(options));
             } catch (e) {
-                if (retryOn(e, retryOpts)) {
+                if (retryOn(attempt, e, retryOpts)) {
                     retryOpts.retryInitialDelay *= retryOpts.retryBackoff; // update retry interval using backoff
 
                     const ms = retryDelay(retryOpts.retryInitialDelay);


### PR DESCRIPTION
Add the `retryMaxCount` option to retry a fixed number of attempts.
The option overrides `retryMaxDuration` when provided

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
