### PR TITLE
Fix mime-type handling in AEM uploads 

### DIFF
--- a/lib/asset/transferasset.js
+++ b/lib/asset/transferasset.js
@@ -17,7 +17,6 @@ const { AssetMetadata } = require("./assetmetadata");
 const { AssetMultipart } = require("./assetmultipart");
 const { AssetVersion } = require("./assetversion");
 const { NameConflictPolicy } = require("./nameconflictpolicy");
-const { MIMETYPE } = require("../constants");
 const { IllegalArgumentError } = require("../error");
 const { urlToPath } = require("../util");
 
@@ -210,7 +209,7 @@ class TransferAsset {
         };
 
         if (this.metadata && this.metadata.contentType) {
-            data.mimeType = this.metadata.contentType || MIMETYPE.APPLICATION_OCTET_STREAM;
+            data.mimeType = this.metadata.contentType;
         }
 
         return data;

--- a/lib/functions/aemcompleteupload.js
+++ b/lib/functions/aemcompleteupload.js
@@ -18,6 +18,7 @@ const { AsyncGeneratorFunction } = require("../generator/function");
 const { TransferEvents } = require("../controller/transfercontroller");
 const { postForm } = require("../fetch");
 const { retry } = require("../retry");
+const { MIMETYPE } = require("../constants");
 
 /**
  * @typedef {Object} AEMCompleteUploadOptions
@@ -61,7 +62,11 @@ class AEMCompleteUpload extends AsyncGeneratorFunction {
                 const form = new URLSearchParams();
                 form.append("fileName", transferAsset.target.filename);
                 form.append("fileSize", transferAsset.metadata.contentLength);
-                form.append("mimeType", transferAsset.metadata.contentType);
+                if (transferAsset.metadata.contentType) {
+                    form.append("mimeType", transferAsset.metadata.contentType);
+                } else {
+                    form.append("mimeType", MIMETYPE.APPLICATION_OCTET_STREAM);
+                }
                 form.append("createVersion", transferAsset.nameConflictPolicy.createVersion);
                 if (transferAsset.nameConflictPolicy.versionLabel) {
                     form.append("versionLabel", transferAsset.nameConflictPolicy.versionLabel);

--- a/lib/functions/aeminitiateupload.js
+++ b/lib/functions/aeminitiateupload.js
@@ -108,9 +108,13 @@ class AEMInitiateUpload extends AsyncGeneratorFunction {
                 const transferAsset = assets[i];
                 const { minPartSize, maxPartSize, uploadURIs, mimeType, uploadToken } = files[i];
 
-                // uploadToken is opaque to us, we just need to send it back with the completeUpload
+                // validate response from the server
+                // note: uploadToken is opaque to us, we just need to send it back with the completeUpload
                 if (!Number.isFinite(minPartSize) || !Number.isFinite(maxPartSize) || !Array.isArray(uploadURIs) || (uploadURIs.length === 0)) {
                     throw Error(`invalid multi-part information for ${transferAsset.target.url}: ${JSON.stringify(files[i])}`);
+                }
+                if (mimeType && typeof mimeType !== "string") {
+                    throw Error(`invalid mime-type for ${transferAsset.target.url}: ${JSON.stringify(mimeType)}`);
                 }
 
                 // if the client has no mimetype specified, use the mimetype provided by AEM

--- a/lib/functions/aeminitiateupload.js
+++ b/lib/functions/aeminitiateupload.js
@@ -114,7 +114,7 @@ class AEMInitiateUpload extends AsyncGeneratorFunction {
                 }
 
                 // if the client has no mimetype specified, use the mimetype provided by AEM, if AEM
-                // cannot detect a mimetype default to application/octet-stream
+                // if AEM cannot detect a mimetype default to application/octet-stream
                 if (!transferAsset.metadata.contentType) {
                     let contentType = mimeType;
                     if (typeof contentType !== "string") {

--- a/lib/functions/aeminitiateupload.js
+++ b/lib/functions/aeminitiateupload.js
@@ -115,7 +115,7 @@ class AEMInitiateUpload extends AsyncGeneratorFunction {
 
                 // if the client has no mimetype specified, use the mimetype provided by AEM, if AEM
                 // cannot detect a mimetype default to application/octet-stream
-                if (!transferAsset.metadata.mimeType) {
+                if (!transferAsset.metadata.contentType) {
                     let contentType = mimeType;
                     if (typeof contentType !== "string") {
                         contentType = MIMETYPE.APPLICATION_OCTET_STREAM;

--- a/lib/functions/aeminitiateupload.js
+++ b/lib/functions/aeminitiateupload.js
@@ -113,7 +113,7 @@ class AEMInitiateUpload extends AsyncGeneratorFunction {
                     throw Error(`invalid multi-part information for ${transferAsset.target.url}: ${JSON.stringify(files[i])}`);
                 }
 
-                // if the client has no mimetype specified, use the mimetype provided by AEM, if AEM
+                // if the client has no mimetype specified, use the mimetype provided by AEM
                 // if AEM cannot detect a mimetype default to application/octet-stream
                 if (!transferAsset.metadata.contentType) {
                     let contentType = mimeType;

--- a/lib/functions/aeminitiateupload.js
+++ b/lib/functions/aeminitiateupload.js
@@ -14,12 +14,14 @@
 
 require("core-js/stable");
 
+const { AssetMetadata } = require("../asset/assetmetadata");
 const { AssetMultipart } = require("../asset/assetmultipart");
 const { AsyncGeneratorFunction } = require("../generator/function");
 const { postForm } = require("../fetch");
 const { retry } = require("../retry");
 const logger = require("../logger");
 const { TransferEvents } = require("../controller/transfercontroller");
+const { MIMETYPE } = require("../constants");
 
 /**
  * @typedef {Object} AEMInitiateUploadOptions
@@ -104,11 +106,27 @@ class AEMInitiateUpload extends AsyncGeneratorFunction {
             const completeUrl = new URL(initiateResponse.completeURI, folderUrl);
             for (let i = 0; i < assets.length; ++i) {
                 const transferAsset = assets[i];
-                const { minPartSize, maxPartSize, uploadURIs, uploadToken } = files[i];
+                const { minPartSize, maxPartSize, uploadURIs, mimeType, uploadToken } = files[i];
+
                 // uploadToken is opaque to us, we just need to send it back with the completeUpload
                 if (!Number.isFinite(minPartSize) || !Number.isFinite(maxPartSize) || !Array.isArray(uploadURIs) || (uploadURIs.length === 0)) {
                     throw Error(`invalid multi-part information for ${transferAsset.target.url}: ${JSON.stringify(files[i])}`);
                 }
+
+                // if the client has no mimetype specified, use the mimetype provided by AEM, if AEM
+                // cannot detect a mimetype default to application/octet-stream
+                if (!transferAsset.metadata.mimeType) {
+                    let contentType = mimeType;
+                    if (typeof contentType !== "string") {
+                        contentType = MIMETYPE.APPLICATION_OCTET_STREAM;
+                    }
+                    transferAsset.metadata = new AssetMetadata(
+                        transferAsset.metadata.filename,
+                        contentType,
+                        transferAsset.metadata.contentLength
+                    );
+                }              
+
                 transferAsset.multipartTarget = new AssetMultipart(
                     uploadURIs,
                     minPartSize,

--- a/lib/functions/aeminitiateupload.js
+++ b/lib/functions/aeminitiateupload.js
@@ -117,7 +117,7 @@ class AEMInitiateUpload extends AsyncGeneratorFunction {
                 // if AEM cannot detect a mimetype default to application/octet-stream
                 if (!transferAsset.metadata.contentType) {
                     let contentType = mimeType;
-                    if (typeof contentType !== "string") {
+                    if (!contentType) {
                         contentType = MIMETYPE.APPLICATION_OCTET_STREAM;
                     }
                     transferAsset.metadata = new AssetMetadata(

--- a/lib/functions/aeminitiateupload.js
+++ b/lib/functions/aeminitiateupload.js
@@ -109,12 +109,23 @@ class AEMInitiateUpload extends AsyncGeneratorFunction {
                 const { minPartSize, maxPartSize, uploadURIs, mimeType, uploadToken } = files[i];
 
                 // validate response from the server
-                // note: uploadToken is opaque to us, we just need to send it back with the completeUpload
                 if (!Number.isFinite(minPartSize) || !Number.isFinite(maxPartSize) || !Array.isArray(uploadURIs) || (uploadURIs.length === 0)) {
                     throw Error(`invalid multi-part information for ${transferAsset.target.url}: ${JSON.stringify(files[i])}`);
                 }
+                if (minPartSize < 1) {
+                    throw Error(`invalid minPartSize for ${transferAsset.target.url}: ${JSON.stringify(files[i])}`);
+                }
+                if (maxPartSize < minPartSize) {
+                    throw Error(`invalid maxPartSize for ${transferAsset.target.url}: ${JSON.stringify(files[i])}`);
+                }
+                if (uploadURIs.findIndex(value => typeof value !== "string") !== -1) {
+                    throw Error(`invalid upload url for ${transferAsset.target.url}: ${JSON.stringify(files[i])}`);
+                }
                 if (mimeType && typeof mimeType !== "string") {
-                    throw Error(`invalid mime-type for ${transferAsset.target.url}: ${JSON.stringify(mimeType)}`);
+                    throw Error(`invalid mimetype for ${transferAsset.target.url}: ${JSON.stringify(files[i])}`);
+                }
+                if (typeof uploadToken !== "string") {
+                    throw Error(`invalid uploadToken for ${transferAsset.target.url}: ${JSON.stringify(files[i])}`);
                 }
 
                 // if the client has no mimetype specified, use the mimetype provided by AEM

--- a/test/aem/aemupload.test.js
+++ b/test/aem/aemupload.test.js
@@ -56,7 +56,7 @@ describe('AEM Upload', function() {
             .reply(201);
 
         nock(HOST)
-            .post('/path/to.completeUpload.json', 'fileName=file-1.jpg&fileSize=15&mimeType=undefined&createVersion=true&versionLabel=versionLabel&versionComment=versionComment&replace=false&uploadToken=upload-token')
+            .post('/path/to.completeUpload.json', 'fileName=file-1.jpg&fileSize=15&mimeType=image%2Fjpeg&createVersion=true&versionLabel=versionLabel&versionComment=versionComment&replace=false&uploadToken=upload-token')
             .reply(200, '{}');
 
         const aemUpload = new AEMUpload();
@@ -107,8 +107,12 @@ describe('AEM Upload', function() {
         assert.deepStrictEqual(events.filestart[0], fileEventData);
         assert.deepStrictEqual(events.fileprogress[0], {
             ...fileEventData,
+            mimeType: "image/jpeg",
             transferred: 15
         });
-        assert.deepStrictEqual(events.fileend[0], fileEventData);
+        assert.deepStrictEqual(events.fileend[0], {
+            ...fileEventData,
+            mimeType: "image/jpeg",
+        });
     });
 });

--- a/test/functions/aeminitiateupload.test.js
+++ b/test/functions/aeminitiateupload.test.js
@@ -129,6 +129,7 @@ describe("AEMInitiateUpload", () => {
                         uploadURIs: [
                             "http://host/path/to/target.png/block"
                         ], 
+                        mimeType: "image/png",
                         uploadToken: "uploadToken"
                     }],
                     completeURI: "/path/to.completeUpload.json"
@@ -141,14 +142,14 @@ describe("AEMInitiateUpload", () => {
                 retryEnabled: false
             });
             const generator = initiateUpload.execute([new TransferAsset(source, target, {
-                metadata: new AssetMetadata(undefined, "image/png", 1234)
+                metadata: new AssetMetadata("target.png", undefined, 1234)
             })], controller);
             
             // check the first file response
             {
                 const { value, done } = await generator.next();
                 assert.deepStrictEqual(value, new TransferAsset(source, target, {
-                    metadata: new AssetMetadata(undefined, "image/png", 1234),
+                    metadata: new AssetMetadata("target.png", "image/png", 1234),
                     multipartTarget: new AssetMultipart([
                         "http://host/path/to/target.png/block"
                     ], 1000, 10000, undefined, "http://host/path/to.completeUpload.json", "uploadToken")
@@ -172,7 +173,7 @@ describe("AEMInitiateUpload", () => {
             nock('http://host')
                 .post(
                     "/path/to.initiateUpload.json", 
-                    "fileName=target1.png&fileSize=1234&fileName=target2.png&fileSize=1234"
+                    "fileName=target1.png&fileSize=1234&fileName=target2.png&fileSize=5678"
                 )
                 .reply(200, JSON.stringify({
                     files: [{
@@ -181,10 +182,12 @@ describe("AEMInitiateUpload", () => {
                         uploadURIs: [
                             "http://host/path/to/target1.png/block"
                         ], 
+                        mimeType: "image/png",
                         uploadToken: "uploadToken1"
                     }, {
                         minPartSize: 2000, 
                         maxPartSize: 20000, 
+                        mimeType: "image/png",
                         uploadURIs: [
                             "http://host/path/to/target2.png/block"
                         ], 
@@ -200,16 +203,16 @@ describe("AEMInitiateUpload", () => {
                 retryEnabled: false
             });
             const generator = initiateUpload.execute([new TransferAsset(source1, target1, {
-                metadata: new AssetMetadata(undefined, "image/png", 1234)
+                metadata: new AssetMetadata("target1.png", undefined, 1234)
             }), new TransferAsset(source2, target2, {
-                metadata: new AssetMetadata(undefined, "image/png", 1234)
+                metadata: new AssetMetadata("target2.png", undefined, 5678)
             })], controller);
             
             // check the first file response
             {
                 const { value, done } = await generator.next();
                 assert.deepStrictEqual(value, new TransferAsset(source1, target1, {
-                    metadata: new AssetMetadata(undefined, "image/png", 1234),
+                    metadata: new AssetMetadata("target1.png", "image/png", 1234),
                     multipartTarget: new AssetMultipart([
                         "http://host/path/to/target1.png/block"
                     ], 1000, 10000, undefined, "http://host/path/to.completeUpload.json", "uploadToken1")
@@ -221,7 +224,7 @@ describe("AEMInitiateUpload", () => {
             {
                 const { value, done } = await generator.next();
                 assert.deepStrictEqual(value, new TransferAsset(source2, target2, {
-                    metadata: new AssetMetadata(undefined, "image/png", 1234),
+                    metadata: new AssetMetadata("target2.png", "image/png", 5678),
                     multipartTarget: new AssetMultipart([
                         "http://host/path/to/target2.png/block"
                     ], 2000, 20000, undefined, "http://host/path/to.completeUpload.json", "uploadToken2")

--- a/test/functions/aeminitiateupload.test.js
+++ b/test/functions/aeminitiateupload.test.js
@@ -343,6 +343,60 @@ describe("AEMInitiateUpload", () => {
         });
     });
     describe("error", () => {
+        it("invalid mimetype response", async () => {
+            const source = new Asset("file:///path/to/source.png");
+            const target = new Asset("http://host/path/to/target.png");
+    
+            nock('http://host')
+                .post(
+                    "/path/to.initiateUpload.json", 
+                    "fileName=target.png&fileSize=1234"
+                )
+                .reply(200, JSON.stringify({
+                    files: [{
+                        minPartSize: 1000, 
+                        maxPartSize: 10000, 
+                        uploadURIs: [
+                            "http://host/path/to/target.png/block"
+                        ], 
+                        mimeType: {},
+                        uploadToken: "uploadToken"
+                    }],
+                    completeURI: "/path/to.completeUpload.json"
+                }), {
+                    "content-type": "application/json"
+                });
+                
+            const controller = new ControllerMock();
+            const initiateUpload = new AEMInitiateUpload({
+                retryEnabled: false
+            });
+            const generator = initiateUpload.execute([new TransferAsset(source, target, {
+                metadata: new AssetMetadata("target.png", undefined, 1234)
+            })], controller);
+
+            const { value, done } = await generator.next();
+            assert.strictEqual(value, undefined);
+            assert.strictEqual(done, true);    
+            
+            // check notifications
+            assert.deepStrictEqual([{
+                "eventName": "AEMInitiateUpload",
+                "functionName": "AEMInitiateUpload",
+                "props": undefined,
+                "transferItem": new TransferAsset(source, target, {
+                    metadata: new AssetMetadata("target.png", undefined, 1234)
+                })
+            }, {
+                "eventName": "error",
+                "functionName": "AEMInitiateUpload",
+                "props": undefined,
+                "error": "invalid mime-type for http://host/path/to/target.png: {}",
+                "transferItem":  new TransferAsset(source, target, {
+                    metadata: new AssetMetadata("target.png", undefined, 1234)
+                })
+            }], controller.notifications);
+        });
         it("http failure", async () => {
             const source = new Asset("file:///path/to/source.jpg");
             const target = new Asset("http://host/path/to/target.jpg");
@@ -370,7 +424,7 @@ describe("AEMInitiateUpload", () => {
             }
 
             // check notifications
-            assert.deepStrictEqual(controller.notifications, [{
+            assert.deepStrictEqual([{
                 "eventName": "AEMInitiateUpload",
                 "functionName": "AEMInitiateUpload",
                 "props": undefined,
@@ -385,7 +439,7 @@ describe("AEMInitiateUpload", () => {
                 "transferItem":  new TransferAsset(source, target, {
                     metadata: new AssetMetadata("target.jpg", undefined, 1234)
                 })
-            }]);
+            }], controller.notifications);
         });
         it("files missing in response", async () => {
             await tryInvalidInitiateUploadResponse({

--- a/test/functions/aeminitiateupload.test.js
+++ b/test/functions/aeminitiateupload.test.js
@@ -341,25 +341,23 @@ describe("AEMInitiateUpload", () => {
                 assert.strictEqual(done, true);    
             }
         });
-    });
-    describe("error", () => {
-        it("invalid mimetype response", async () => {
-            const source = new Asset("file:///path/to/source.png");
-            const target = new Asset("http://host/path/to/target.png");
+        it("single asset, minPartSize == maxPartSize", async () => {
+            const source = new Asset("file:///path/to/source.jpg");
+            const target = new Asset("http://host/path/to/target.jpg");
     
             nock('http://host')
                 .post(
                     "/path/to.initiateUpload.json", 
-                    "fileName=target.png&fileSize=1234"
+                    "fileName=target.jpg&fileSize=1234"
                 )
                 .reply(200, JSON.stringify({
                     files: [{
-                        minPartSize: 1000, 
-                        maxPartSize: 10000, 
+                        minPartSize: 1, 
+                        maxPartSize: 1, 
                         uploadURIs: [
-                            "http://host/path/to/target.png/block"
+                            "http://host/path/to/target.jpg/block"
                         ], 
-                        mimeType: {},
+                        mimeType: "server/mimetype",
                         uploadToken: "uploadToken"
                     }],
                     completeURI: "/path/to.completeUpload.json"
@@ -372,31 +370,30 @@ describe("AEMInitiateUpload", () => {
                 retryEnabled: false
             });
             const generator = initiateUpload.execute([new TransferAsset(source, target, {
-                metadata: new AssetMetadata("target.png", undefined, 1234)
+                metadata: new AssetMetadata("target.jpg", "image/jpg", 1234)
             })], controller);
-
-            const { value, done } = await generator.next();
-            assert.strictEqual(value, undefined);
-            assert.strictEqual(done, true);    
             
-            // check notifications
-            assert.deepStrictEqual([{
-                "eventName": "AEMInitiateUpload",
-                "functionName": "AEMInitiateUpload",
-                "props": undefined,
-                "transferItem": new TransferAsset(source, target, {
-                    metadata: new AssetMetadata("target.png", undefined, 1234)
-                })
-            }, {
-                "eventName": "error",
-                "functionName": "AEMInitiateUpload",
-                "props": undefined,
-                "error": "invalid mime-type for http://host/path/to/target.png: {}",
-                "transferItem":  new TransferAsset(source, target, {
-                    metadata: new AssetMetadata("target.png", undefined, 1234)
-                })
-            }], controller.notifications);
+            // check the first file response
+            {
+                const { value, done } = await generator.next();
+                assert.deepStrictEqual(value, new TransferAsset(source, target, {
+                    metadata: new AssetMetadata("target.jpg", "image/jpg", 1234),
+                    multipartTarget: new AssetMultipart([
+                        "http://host/path/to/target.jpg/block"
+                    ], 1, 1, undefined, "http://host/path/to.completeUpload.json", "uploadToken")
+                }));
+                assert.strictEqual(done, false);    
+            }
+    
+            // ensure there are no more files
+            {
+                const { value, done } = await generator.next();
+                assert.strictEqual(value, undefined);
+                assert.strictEqual(done, true);    
+            }
         });
+    });
+    describe("error", () => {       
         it("http failure", async () => {
             const source = new Asset("file:///path/to/source.jpg");
             const target = new Asset("http://host/path/to/target.jpg");
@@ -441,18 +438,24 @@ describe("AEMInitiateUpload", () => {
                 })
             }], controller.notifications);
         });
-        it("files missing in response", async () => {
+        it("files missing", async () => {
             await tryInvalidInitiateUploadResponse({
                 completeURI: "/path/to.completeUpload.json"
             }, "'files' field missing in initiateUpload response: {\"completeURI\":\"/path/to.completeUpload.json\"}");
         });
-        it("files mismatch in response", async () => {
+        it("files length mismatch", async () => {
             await tryInvalidInitiateUploadResponse({
                 files: [],
                 completeURI: "/path/to.completeUpload.json"
             }, "'files' field incomplete in initiateUpload response (expected files: 1): {\"files\":[],\"completeURI\":\"/path/to.completeUpload.json\"}");
         });
-        it("completeURI missing in response", async () => {
+        it("files element invalid type", async () => {
+            await tryInvalidInitiateUploadResponse({
+                files: [ "abc" ],
+                completeURI: "/path/to.completeUpload.json"
+            }, "invalid multi-part information for http://host/path/to/target.png: \"abc\"");
+        });
+        it("completeURI missing", async () => {
             await tryInvalidInitiateUploadResponse({
                 files: [{
                     minPartSize: 1000, 
@@ -460,9 +463,24 @@ describe("AEMInitiateUpload", () => {
                     uploadURIs: [
                         "http://host/path/to/target.png/block"
                     ], 
+                    mimeType: "image/png",
+                    uploadToken: "uploadToken"
+                }]
+            }, "'completeURI' field invalid in initiateUpload response: {\"files\":[{\"minPartSize\":1000,\"maxPartSize\":10000,\"uploadURIs\":[\"http://host/path/to/target.png/block\"],\"mimeType\":\"image/png\",\"uploadToken\":\"uploadToken\"}]}");
+        });
+        it("completeURI not a string", async () => {
+            await tryInvalidInitiateUploadResponse({
+                files: [{
+                    minPartSize: 1000, 
+                    maxPartSize: 10000, 
+                    uploadURIs: [
+                        "http://host/path/to/target.png/block"
+                    ], 
+                    mimeType: "image/png",
                     uploadToken: "uploadToken"
                 }],
-            }, "'completeURI' field invalid in initiateUpload response: {\"files\":[{\"minPartSize\":1000,\"maxPartSize\":10000,\"uploadURIs\":[\"http://host/path/to/target.png/block\"],\"uploadToken\":\"uploadToken\"}]}");
+                completeURI: {}
+            }, "'completeURI' field invalid in initiateUpload response: {\"files\":[{\"minPartSize\":1000,\"maxPartSize\":10000,\"uploadURIs\":[\"http://host/path/to/target.png/block\"],\"mimeType\":\"image/png\",\"uploadToken\":\"uploadToken\"}],\"completeURI\":{}}");
         });
         it("minPartSize missing", async () => {
             await tryInvalidInitiateUploadResponse({
@@ -471,10 +489,25 @@ describe("AEMInitiateUpload", () => {
                     uploadURIs: [
                         "http://host/path/to/target.png/block"
                     ], 
+                    mimeType: "image/png",
                     uploadToken: "uploadToken"
                 }],
                 completeURI: "/path/to.completeUpload.json"
-            }, "invalid multi-part information for http://host/path/to/target.png: {\"maxPartSize\":10000,\"uploadURIs\":[\"http://host/path/to/target.png/block\"],\"uploadToken\":\"uploadToken\"}");
+            }, "invalid multi-part information for http://host/path/to/target.png: {\"maxPartSize\":10000,\"uploadURIs\":[\"http://host/path/to/target.png/block\"],\"mimeType\":\"image/png\",\"uploadToken\":\"uploadToken\"}");
+        });
+        it("minPartSize invalid number", async () => {
+            await tryInvalidInitiateUploadResponse({
+                files: [{
+                    minPartSize: 0,
+                    maxPartSize: 10000, 
+                    uploadURIs: [
+                        "http://host/path/to/target.png/block"
+                    ], 
+                    mimeType: "image/png",
+                    uploadToken: "uploadToken"
+                }],
+                completeURI: "/path/to.completeUpload.json"
+            }, "invalid minPartSize for http://host/path/to/target.png: {\"minPartSize\":0,\"maxPartSize\":10000,\"uploadURIs\":[\"http://host/path/to/target.png/block\"],\"mimeType\":\"image/png\",\"uploadToken\":\"uploadToken\"}");
         });
         it("maxPartSize missing", async () => {
             await tryInvalidInitiateUploadResponse({
@@ -483,20 +516,36 @@ describe("AEMInitiateUpload", () => {
                     uploadURIs: [
                         "http://host/path/to/target.png/block"
                     ], 
+                    mimeType: "image/png",
                     uploadToken: "uploadToken"
                 }],
                 completeURI: "/path/to.completeUpload.json"
-            }, "invalid multi-part information for http://host/path/to/target.png: {\"minPartSize\":1000,\"uploadURIs\":[\"http://host/path/to/target.png/block\"],\"uploadToken\":\"uploadToken\"}");
+            }, "invalid multi-part information for http://host/path/to/target.png: {\"minPartSize\":1000,\"uploadURIs\":[\"http://host/path/to/target.png/block\"],\"mimeType\":\"image/png\",\"uploadToken\":\"uploadToken\"}");
+        });
+        it("maxPartSize invalid number", async () => {
+            await tryInvalidInitiateUploadResponse({
+                files: [{
+                    minPartSize: 2,
+                    maxPartSize: 1, 
+                    uploadURIs: [
+                        "http://host/path/to/target.png/block"
+                    ], 
+                    mimeType: "image/png",
+                    uploadToken: "uploadToken"
+                }],
+                completeURI: "/path/to.completeUpload.json"
+            }, "invalid maxPartSize for http://host/path/to/target.png: {\"minPartSize\":2,\"maxPartSize\":1,\"uploadURIs\":[\"http://host/path/to/target.png/block\"],\"mimeType\":\"image/png\",\"uploadToken\":\"uploadToken\"}");
         });
         it("uploadURIs missing", async () => {
             await tryInvalidInitiateUploadResponse({
                 files: [{
                     minPartSize: 1000, 
                     maxPartSize: 10000, 
+                    mimeType: "image/png",
                     uploadToken: "uploadToken"
                 }],
                 completeURI: "/path/to.completeUpload.json"
-            }, "invalid multi-part information for http://host/path/to/target.png: {\"minPartSize\":1000,\"maxPartSize\":10000,\"uploadToken\":\"uploadToken\"}");
+            }, "invalid multi-part information for http://host/path/to/target.png: {\"minPartSize\":1000,\"maxPartSize\":10000,\"mimeType\":\"image/png\",\"uploadToken\":\"uploadToken\"}");
         });
         it("uploadURIs array empty", async () => {
             await tryInvalidInitiateUploadResponse({
@@ -504,10 +553,70 @@ describe("AEMInitiateUpload", () => {
                     minPartSize: 1000, 
                     maxPartSize: 10000, 
                     uploadURIs: [], 
+                    mimeType: "image/png",
                     uploadToken: "uploadToken"
                 }],
                 completeURI: "/path/to.completeUpload.json"
-            }, "invalid multi-part information for http://host/path/to/target.png: {\"minPartSize\":1000,\"maxPartSize\":10000,\"uploadURIs\":[],\"uploadToken\":\"uploadToken\"}");
+            }, "invalid multi-part information for http://host/path/to/target.png: {\"minPartSize\":1000,\"maxPartSize\":10000,\"uploadURIs\":[],\"mimeType\":\"image/png\",\"uploadToken\":\"uploadToken\"}");
+        });
+        it("first uploadURI element invalid", async () => {
+            await tryInvalidInitiateUploadResponse({
+                files: [{
+                    minPartSize: 1000, 
+                    maxPartSize: 10000, 
+                    uploadURIs: [ null ], 
+                    mimeType: "image/png",
+                    uploadToken: "uploadToken"
+                }],
+                completeURI: "/path/to.completeUpload.json"
+            }, "invalid upload url for http://host/path/to/target.png: {\"minPartSize\":1000,\"maxPartSize\":10000,\"uploadURIs\":[null],\"mimeType\":\"image/png\",\"uploadToken\":\"uploadToken\"}");
+        });
+        it("second uploadURI element invalid", async () => {
+            await tryInvalidInitiateUploadResponse({
+                files: [{
+                    minPartSize: 1000, 
+                    maxPartSize: 10000, 
+                    uploadURIs: [ "http://host/path/to/target.png/block", null ], 
+                    mimeType: "image/png",
+                    uploadToken: "uploadToken"
+                }],
+                completeURI: "/path/to.completeUpload.json"
+            }, "invalid upload url for http://host/path/to/target.png: {\"minPartSize\":1000,\"maxPartSize\":10000,\"uploadURIs\":[\"http://host/path/to/target.png/block\",null],\"mimeType\":\"image/png\",\"uploadToken\":\"uploadToken\"}");
+        });
+        it("invalid mimetype", async () => {          
+            await tryInvalidInitiateUploadResponse({
+                files: [{
+                    minPartSize: 1000, 
+                    maxPartSize: 10000, 
+                    uploadURIs: [ "http://host/path/to/target.png/block" ], 
+                    mimeType: {},
+                    uploadToken: "uploadToken"
+                }],
+                completeURI: "/path/to.completeUpload.json"
+            }, "invalid mimetype for http://host/path/to/target.png: {\"minPartSize\":1000,\"maxPartSize\":10000,\"uploadURIs\":[\"http://host/path/to/target.png/block\"],\"mimeType\":{},\"uploadToken\":\"uploadToken\"}");
+        });
+        it("uploadToken missing", async () => {          
+            await tryInvalidInitiateUploadResponse({
+                files: [{
+                    minPartSize: 1000, 
+                    maxPartSize: 10000, 
+                    uploadURIs: [ "http://host/path/to/target.png/block" ], 
+                    mimeType: "image/png"
+                }],
+                completeURI: "/path/to.completeUpload.json"
+            }, "invalid uploadToken for http://host/path/to/target.png: {\"minPartSize\":1000,\"maxPartSize\":10000,\"uploadURIs\":[\"http://host/path/to/target.png/block\"],\"mimeType\":\"image/png\"}");
+        });
+        it("invalid uploadToken", async () => {          
+            await tryInvalidInitiateUploadResponse({
+                files: [{
+                    minPartSize: 1000, 
+                    maxPartSize: 10000, 
+                    uploadURIs: [ "http://host/path/to/target.png/block" ], 
+                    mimeType: "image/png",
+                    uploadToken: {}
+                }],
+                completeURI: "/path/to.completeUpload.json"
+            }, "invalid uploadToken for http://host/path/to/target.png: {\"minPartSize\":1000,\"maxPartSize\":10000,\"uploadURIs\":[\"http://host/path/to/target.png/block\"],\"mimeType\":\"image/png\",\"uploadToken\":{}}");
         });
     });
 });


### PR DESCRIPTION
## Description

The key fix is that AEM provides the mimeType of the asset from the initiate upload servlet. This has to be passed along to when we invoke the complete upload servlet. This did not happen, resulting in a mimeType that was `"undefined"`.

In addition this PR adds missing and update test coverage that cover the bug.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
