### PR TITLE
add option for specifying headers to include in multipart upload requests

### DIFF
--- a/lib/aem/aemupload.js
+++ b/lib/aem/aemupload.js
@@ -47,7 +47,7 @@ async function* generateAEMUploadTransferRecords(options) {
         const targetUrl = new URL(uploadFile.fileUrl);
 
         const source = new Asset(sourceUrl);
-        const target = new Asset(targetUrl, options.headers);
+        const target = new Asset(targetUrl, options.headers, uploadFile.multipartHeaders);
 
         const transferAsset = new TransferAsset(source, target, {
             acceptRanges: true,

--- a/lib/asset/asset.js
+++ b/lib/asset/asset.js
@@ -29,18 +29,21 @@ class Asset {
      * 
      * @param {URL|String|Blob} url URL of the asset (http, https, or file), can also be a Blob for browser uploads
      * @param {Headers} [headers] Headers to send to request or store the asset 
+     * @param {Headers} [multipartHeaders] Headers to send with each part request
      */
-    constructor(url, headers) {
+    constructor(url, headers, multipartHeaders) {
         if (typeof url === "string" || url instanceof URL) {
             this[PRIVATE] = {
                 url: new URL(url),
-                headers
+                headers,
+                multipartHeaders
             };
         } else {
             this[PRIVATE] = {
                 url: "blob://",
                 blob: url,
-                headers
+                headers,
+                multipartHeaders
             };
         }
     }
@@ -90,6 +93,15 @@ class Asset {
      */
     get headers() {
         return this[PRIVATE].headers;
+    }
+
+    /**
+     * Headers to send with each part request transfering in multipart.
+     * 
+     * @returns {Headers} Headers to send to request or store the asset 
+     */
+    get multipartHeaders() {
+        return this[PRIVATE].multipartHeaders;
     }
 }
 

--- a/lib/functions/aeminitiateupload.js
+++ b/lib/functions/aeminitiateupload.js
@@ -146,7 +146,7 @@ class AEMInitiateUpload extends AsyncGeneratorFunction {
                     uploadURIs,
                     minPartSize,
                     maxPartSize,
-                    undefined,
+                    transferAsset.target.multipartHeaders,
                     completeUrl,
                     uploadToken
                 );

--- a/test/aem/aemupload.test.js
+++ b/test/aem/aemupload.test.js
@@ -51,7 +51,13 @@ describe('AEM Upload', function() {
                 'Content-Length': initRaw.length
             });
 
-        nock(HOST)
+        nock(HOST, {
+            reqheaders: {
+                'content-length': 15,
+                'content-type': 'image/jpeg',
+                partHeader: 'test'
+            }
+        })
             .put('/part', 'hello world 123')
             .reply(201);
 
@@ -81,7 +87,8 @@ describe('AEM Upload', function() {
                 fileSize: 15,
                 createVersion: true,
                 versionLabel: 'versionLabel',
-                versionComment: 'versionComment'
+                versionComment: 'versionComment',
+                multipartHeaders: { partHeader: 'test' }
             }],
             headers: {},
             concurrent: true,

--- a/test/functions/aeminitiateupload.test.js
+++ b/test/functions/aeminitiateupload.test.js
@@ -114,8 +114,9 @@ describe("AEMInitiateUpload", () => {
             assert.strictEqual(done, true);
         });
         it("single asset", async () => {
+            const partHeaders = { partHeader: 'testing' };
             const source = new Asset("file:///path/to/source.png");
-            const target = new Asset("http://host/path/to/target.png");
+            const target = new Asset("http://host/path/to/target.png", undefined, partHeaders);
     
             nock('http://host')
                 .post(
@@ -152,7 +153,7 @@ describe("AEMInitiateUpload", () => {
                     metadata: new AssetMetadata("target.png", "image/png", 1234),
                     multipartTarget: new AssetMultipart([
                         "http://host/path/to/target.png/block"
-                    ], 1000, 10000, undefined, "http://host/path/to.completeUpload.json", "uploadToken")
+                    ], 1000, 10000, partHeaders, "http://host/path/to.completeUpload.json", "uploadToken")
                 }));
                 assert.strictEqual(done, false);    
             }


### PR DESCRIPTION
## Description

This resolves issue #66.

Adds a new `uploadFile.multipartHeaders` option for specifying the headers that are sent when parts are uploaded to Azure.

For example, assume the following upload file options:

```
{
  fileUrl: '<target URL of new file>',
  filePath: '<full path to local file to upload>',
  fileSize: 15,
  multipartHeaders: {
    'user-agent': '<my custom user agent>'
  }
}
```
When the parts of the specified file are uploaded to the individual part URLs provided by AEM's initiate upload servlet, the requests will include the specified `user-agent` header in addition to the other headers that the module uses by default.

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
