### PR TITLE
fix issues when using module in a browser.

### DIFF
--- a/lib/aem/aemupload.js
+++ b/lib/aem/aemupload.js
@@ -33,6 +33,7 @@ const { RandomFileAccess } = require("../randomfileaccess");
 const EventEmitter = require("events");
 const UploadError = require("./upload-error");
 const { FilterFailedAssets } = require("../functions/filterfailedassets");
+const { IllegalArgumentError } = require('../error');
 
 /**
  * Generate AEM upload transfer assets
@@ -43,7 +44,16 @@ const { FilterFailedAssets } = require("../functions/filterfailedassets");
  */
 async function* generateAEMUploadTransferRecords(options) {
     for (const uploadFile of options.uploadFiles) {
-        const sourceUrl = fileUrl(uploadFile.filePath);
+        let sourceUrl = uploadFile.blob;
+        if (!sourceUrl) {
+            if (!uploadFile.filePath) {
+                throw new IllegalArgumentError(
+                    'Either blob or filePath must be provided in uploadFiles',
+                    JSON.stringify(uploadFile),
+                );
+            }
+            sourceUrl = fileUrl(uploadFile.filePath);
+        }
         const targetUrl = new URL(uploadFile.fileUrl);
 
         const source = new Asset(sourceUrl);

--- a/lib/aem/aemupload.js
+++ b/lib/aem/aemupload.js
@@ -33,7 +33,7 @@ const { RandomFileAccess } = require("../randomfileaccess");
 const EventEmitter = require("events");
 const UploadError = require("./upload-error");
 const { FilterFailedAssets } = require("../functions/filterfailedassets");
-const { IllegalArgumentError } = require('../error');
+const { IllegalArgumentError } = require("../error");
 
 /**
  * Generate AEM upload transfer assets
@@ -49,7 +49,7 @@ async function* generateAEMUploadTransferRecords(options) {
             if (!uploadFile.filePath) {
                 throw new IllegalArgumentError(
                     'Either blob or filePath must be provided in uploadFiles',
-                    JSON.stringify(uploadFile),
+                    JSON.stringify(uploadFile)
                 );
             }
             sourceUrl = fileUrl(uploadFile.filePath);

--- a/lib/aem/upload-error.js
+++ b/lib/aem/upload-error.js
@@ -68,6 +68,8 @@ class UploadError extends Error {
                 code = errorCodes.NOT_AUTHORIZED;
             } else if (status === 404) {
                 code = errorCodes.NOT_FOUND;
+            } else if (status === 413) {
+                code = errorCodes.TOO_LARGE;
             } else if (status === 501) {
                 code = errorCodes.NOT_SUPPORTED;
             }

--- a/lib/asset/asset.js
+++ b/lib/asset/asset.js
@@ -13,7 +13,8 @@
 "use strict";
 
 require("core-js/stable");
-const { dirname: urlPathDirname, basename: urlPathBasename } = require("path").posix;
+const { basename: filePathBasename } = require("path");
+const { urlPathDirname } = require("../util");
 
 const PRIVATE = Symbol("PRIVATE");
 
@@ -63,7 +64,7 @@ class Asset {
      * @returns {String} Asset filename without path
      */
     get filename() {
-        return decodeURIComponent(urlPathBasename(this.url.pathname));
+        return decodeURIComponent(filePathBasename(this.url.pathname));
     }
 
     /**

--- a/lib/asset/transferasset.js
+++ b/lib/asset/transferasset.js
@@ -197,8 +197,8 @@ class TransferAsset {
      * @returns {*} File event data.
      */
     get eventData() {
-        const sourcePath = urlToPath(this.source.url.href);
-        const targetPath = urlToPath(this.target.url.href);
+        const sourcePath = urlToPath(this.source.url);
+        const targetPath = urlToPath(this.target.url);
         const data = {
             fileName: targetPath.name,
             fileSize: this.metadata && this.metadata.contentLength,

--- a/lib/fetch.js
+++ b/lib/fetch.js
@@ -12,7 +12,7 @@
 
 "use strict";
 
-const fetch = require("node-fetch-npm");
+const nodeFetch = require("node-fetch-npm");
 const { HttpResponseError, HttpConnectError, HttpStreamError } = require("./error");
 const { HTTP, MIMETYPE } = require("./constants");
 
@@ -112,6 +112,15 @@ async function readTextStream(stream, maxLength) {
  * @returns {*} response
  */
 async function stream(method, url, options) {
+    // only attempt to use node-fetch if running in the context of Node.js.
+    // "window" and "window.fetch" will be defined when running in a
+    // browser - so use the browser's fetch in that case
+    let fetch = nodeFetch;
+    // eslint-disable-next-line no-undef
+    if ((typeof window !== 'undefined') && window.fetch) {
+        // eslint-disable-next-line no-undef
+        fetch = window.fetch;
+    }
     const request = {method, ...options};
     let response;
     try {
@@ -139,6 +148,40 @@ async function stream(method, url, options) {
 }
 
 /**
+ * Uses this file's "stream" method to submit an HTTP request. If the response to
+ * the request has a body that is a stream, this method will use the stream's
+ * events to provide the response to the request.
+ *
+ * If the response _doesn't_ provide a streamed body, the method will return
+ * the response as-is.
+ *
+ * The purpose of this method is primarily to process the response differently,
+ * depending on whether it was initiated from Node.JS or from a browser.
+ *
+ * @param {String} method HTTP method of the request to submit.
+ * @param {String} url URL of the request to submit.
+ * @param {Object} options Additional options to provide to fetch when
+ *  submitting the request.
+ * @returns {*} HTTP response of the request.
+ */
+async function handleStream(method, url, options) {
+    const response = await stream(method, url, options);
+    if (response.body && response.body.on) {
+        return new Promise((resolve, reject) => {
+            response.body.on("data", () => {});
+            response.body.on("end", () => {
+                resolve(response);
+            });
+            response.body.on("error", error => {
+                const errorMethod = (options && options.method) || method;
+                reject(new HttpStreamError(errorMethod, url, response.status, error));
+            });
+        });
+    }
+    return response;
+}
+
+/**
  * Retrieve headers and status from the given URL.
  * Defaults to "HEAD" method.
  * The response stream is closed on success.
@@ -147,17 +190,7 @@ async function stream(method, url, options) {
  * @param {Object} options Fetch options
  */
 async function issueHead(url, options) {
-    const response = await stream(HTTP.METHOD.HEAD, url, options);
-    return new Promise((resolve, reject) => {
-        response.body.on("data", () => {});
-        response.body.on("end", () => {
-            resolve(response);
-        });
-        response.body.on("error", error => {
-            const method = (options && options.method) || HTTP.METHOD.HEAD;
-            reject(new HttpStreamError(method, url, response.status, error));
-        });
-    });
+    return handleStream(HTTP.METHOD.HEAD, url, options);
 }
 
 /**
@@ -181,17 +214,7 @@ async function streamGet(url, options) {
  * @param {Object} options Fetch options
  */
 async function issuePut(url, options) {
-    const response = await stream(HTTP.METHOD.PUT, url, options);
-    return new Promise((resolve, reject) => {
-        response.body.on("data", () => {});
-        response.body.on("end", () => {
-            resolve(response);
-        });
-        response.body.on("error", error => {
-            const method = (options && options.method) || HTTP.METHOD.PUT;
-            reject(new HttpStreamError(method, url, response.status, error));
-        });
-    });
+    return handleStream(HTTP.METHOD.PUT, url, options);
 }
 
 /**

--- a/lib/fetch.js
+++ b/lib/fetch.js
@@ -166,7 +166,7 @@ async function stream(method, url, options) {
  */
 async function handleStream(method, url, options) {
     const response = await stream(method, url, options);
-    if (response.body && response.body.on) {
+    if (response && response.body && response.body.on) {
         return new Promise((resolve, reject) => {
             response.body.on("data", () => {});
             response.body.on("end", () => {

--- a/lib/util.js
+++ b/lib/util.js
@@ -14,8 +14,7 @@
 
 require("core-js/stable");
 
-const { sep, dirname: filePathDirname, basename: filePathBasename } = require('path');
-const { dirname: urlPathDirname, basename: urlPathBasename } = require("path").posix;
+const { sep, dirname: filePathDirname, basename: filePathBasename, posix } = require('path');
 const fs = require('fs');
 const validUrl = require('valid-url');
 const { HttpStreamError } = require("./error");
@@ -154,6 +153,33 @@ async function streamToBuffer(method, url, status, stream, totalSize) {
 }
 
 /**
+ * Ensures that all path separators in a given path are forward
+ * slashes. The method will replace any backward slashes with
+ * forward slashes.
+ *
+ * @param {String} path Path to be processed.
+ * @returns {String} Path whose separators are forward slashes.
+ */
+function ensureForwardSlashes(path) {
+    return path.replaceAll(/\\/g, '/');
+}
+
+/**
+ * Retrieves the parent directory path of a given file path.
+ * The separators in the returned path will always be forward
+ * slashes, regardless of the operating system.
+ *
+ * @param {String} path Path to be processed.
+ * @returns {String} Path whose separators are forward slashes.
+ */
+function urlPathDirname(path) {
+    if (posix) {
+        return posix.dirname(path);
+    }
+    return ensureForwardSlashes(filePathDirname(path));
+}
+
+/**
  * @typedef {Object} PathInformation Information about the URL's path.
  * @property {string} path Full path from the URL.
  * @property {string} name Name of the item from the URL's path.
@@ -179,7 +205,7 @@ function urlToPath(path) {
     const url = new URL(path);
     let urlPath = decodeURIComponent(url.pathname);
     let parentPath = urlPathDirname(urlPath);
-    let name = urlPathBasename(urlPath);
+    const name = filePathBasename(urlPath);
 
     if (url.protocol === "file:") {
         // windows paths will have a forward slash followed by
@@ -190,7 +216,6 @@ function urlToPath(path) {
         }
         urlPath = urlPath.replace(/\//g, sep);
         parentPath = filePathDirname(urlPath);
-        name = filePathBasename(urlPath);
     }
 
     return {
@@ -208,5 +233,6 @@ module.exports = {
     isFileProtocol,
     isPositiveNumber,
     streamToBuffer,
+    urlPathDirname,
     urlToPath,
 };

--- a/lib/util.js
+++ b/lib/util.js
@@ -14,9 +14,9 @@
 
 require("core-js/stable");
 
-const { sep, dirname: filePathDirname, basename: filePathBasename, posix } = require('path');
-const fs = require('fs');
-const validUrl = require('valid-url');
+const { sep, dirname: filePathDirname, basename: filePathBasename } = require("path");
+const fs = require("fs");
+const validUrl = require("valid-url");
 const { HttpStreamError } = require("./error");
 
 /**
@@ -173,9 +173,6 @@ function ensureForwardSlashes(path) {
  * @returns {String} Path whose separators are forward slashes.
  */
 function urlPathDirname(path) {
-    if (posix) {
-        return posix.dirname(path);
-    }
     return ensureForwardSlashes(filePathDirname(path));
 }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -2337,6 +2337,12 @@
       "dev": true,
       "optional": true
     },
+    "blob-polyfill": {
+      "version": "6.0.20211015",
+      "resolved": "https://registry.npmjs.org/blob-polyfill/-/blob-polyfill-6.0.20211015.tgz",
+      "integrity": "sha512-OGL4bm6ZNpdFAvQugRlQy5MNly8gk15aWi/ZhQHimQsrx9WKD05r+v+xNgHCChLER3MH+9KLAhzuFlwFKrH1Yw==",
+      "dev": true
+    },
     "bottleneck": {
       "version": "2.19.5",
       "resolved": "https://registry.npmjs.org/bottleneck/-/bottleneck-2.19.5.tgz",

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "@babel/polyfill": "^7.12.1",
     "@babel/preset-env": "^7.14.0",
     "@semantic-release/git": "^9.0.0",
+    "blob-polyfill": "^6.0.20211015",
     "codecov": "^3.8.2",
     "conventional-changelog-eslint": "^3.0.9",
     "license-checker": "^25.0.1",

--- a/test/aem/upload-error.test.js
+++ b/test/aem/upload-error.test.js
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2021 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+/* eslint-env mocha */
+
+'use strict';
+
+const assert = require("assert");
+const UploadError = require("../../lib/aem/upload-error");
+const errorCodes = require("../../lib/aem/error-codes");
+
+describe('Upload Error', function() {
+    function verifyCodes(httpStatus, expectedCode) {
+        const uploadError = UploadError.fromError({ status: httpStatus });
+        assert.strictEqual(uploadError.getCode(), expectedCode);
+        assert.strictEqual(uploadError.getHttpStatusCode(), httpStatus);
+    }
+
+    it('from error', function() {
+        let uploadError = new UploadError('testing', 404);
+        assert.strictEqual(UploadError.fromError(uploadError), uploadError);
+        verifyCodes(404, errorCodes.NOT_FOUND);
+        verifyCodes(409, errorCodes.ALREADY_EXISTS);
+        verifyCodes(403, errorCodes.FORBIDDEN);
+        verifyCodes(400, errorCodes.INVALID_OPTIONS);
+        verifyCodes(401, errorCodes.NOT_AUTHORIZED);
+        verifyCodes(501, errorCodes.NOT_SUPPORTED);
+        verifyCodes(413, errorCodes.TOO_LARGE);
+        verifyCodes(500, errorCodes.UNKNOWN);
+        assert.strictEqual(UploadError.fromError({ response: { status: 500 } }).getCode(), errorCodes.UNKNOWN);
+
+        uploadError = UploadError.fromError({
+            message: 'test error',
+            code: 'MY CODE'
+        }, 'My Overall Message');
+        assert.strictEqual(uploadError.getMessage(), 'My Overall Message: test error');
+        assert.strictEqual(uploadError.getCode(), 'MY CODE');
+
+        uploadError = UploadError.fromError({
+            message: 'test error'
+        });
+        assert.strictEqual(uploadError.getMessage(), 'test error');
+        assert.strictEqual(uploadError.getCode(), errorCodes.UNKNOWN);
+
+        uploadError = UploadError.fromError('some error');
+        assert.strictEqual(uploadError.getMessage(), 'some error');
+        assert.strictEqual(uploadError.getCode(), errorCodes.UNKNOWN);
+
+        const randomError = { hello: 'world!' };
+        uploadError = UploadError.fromError(randomError);
+        assert.strictEqual(uploadError.getMessage(), JSON.stringify(randomError));
+        assert.strictEqual(uploadError.getCode(), errorCodes.UNKNOWN);
+    });
+
+    it('to json', function() {
+        let uploadError = new UploadError('testing', errorCodes.ALREADY_EXISTS);
+        let errorJson = uploadError.toJSON();
+        assert.strictEqual(errorJson.message, 'testing');
+        assert.strictEqual(errorJson.code, errorCodes.ALREADY_EXISTS);
+        assert(!errorJson.innerStack);
+
+        uploadError = new UploadError('testing again', errorCodes.NOT_AUTHORIZED, 'inner stack');
+        errorJson = uploadError.toJSON();
+        assert.strictEqual(errorJson.message, 'testing again');
+        assert.strictEqual(errorJson.code, errorCodes.NOT_AUTHORIZED);
+        assert.strictEqual(errorJson.innerStack, 'inner stack');
+        assert.strictEqual(uploadError.toString(), JSON.stringify(errorJson));
+        assert.strictEqual(uploadError.getInnerStack(), 'inner stack');
+    });
+});

--- a/test/util.test.js
+++ b/test/util.test.js
@@ -140,4 +140,9 @@ describe("util", function() {
             parentPath: `C:${path.sep}test space`,
         });
     });
+
+    it('url path dirname', function() {
+        assert.strictEqual(util.urlPathDirname(`${path.sep}my${path.sep}test${path.sep}path`), '/my/test');
+        assert.strictEqual(util.urlPathDirname(`${path.sep}my${path.sep}test${path.sep}file.jpg`), '/my/test');
+    });
 });

--- a/test/util.test.js
+++ b/test/util.test.js
@@ -144,5 +144,7 @@ describe("util", function() {
     it('url path dirname', function() {
         assert.strictEqual(util.urlPathDirname(`${path.sep}my${path.sep}test${path.sep}path`), '/my/test');
         assert.strictEqual(util.urlPathDirname(`${path.sep}my${path.sep}test${path.sep}file.jpg`), '/my/test');
+        assert.strictEqual(util.urlPathDirname('/my/test/path'), '/my/test');
+        assert.strictEqual(util.urlPathDirname('/my/test/file.jpg'), '/my/test');
     });
 });


### PR DESCRIPTION
## Description

Provides various changes to allow this module to be used in both a browser and Node.JS context:

* Refactor usage of `posix` from the `path` module, since it's not available when run in a browser.
* Support passing a `blob` option when uploading files with `AEMUpload`.
* Fix cases where the module was assuming the response body of a request would always be a stream; it's not a stream when running in a browser.
* Changed so that `window.fetch` is used instead of `node-fetch-npm` when running in a browser. `node-fetch-npm` was only designed to run in Node.JS, so it wasn't working correctly in this case.

Fixes #69 

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- ~[ ] My change requires a change to the documentation.~
- ~[ ] I have updated the documentation accordingly.~
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
