### PR TITLE
clarify error message when direct binary upload not enabled.

### DIFF
--- a/lib/functions/aeminitiateupload.js
+++ b/lib/functions/aeminitiateupload.js
@@ -17,6 +17,8 @@ require("core-js/stable");
 const { AssetMetadata } = require("../asset/assetmetadata");
 const { AssetMultipart } = require("../asset/assetmultipart");
 const { AsyncGeneratorFunction } = require("../generator/function");
+const UploadError = require("../aem/upload-error");
+const ErrorCodes = require("../aem/error-codes");
 const { postForm } = require("../fetch");
 const { retry } = require("../retry");
 const logger = require("../logger");
@@ -94,7 +96,7 @@ class AEMInitiateUpload extends AsyncGeneratorFunction {
                 });
             }, this.options);
             if (!Array.isArray(initiateResponse.files)) {
-                throw Error(`'files' field missing in initiateUpload response: ${JSON.stringify(initiateResponse)}`);
+                throw new UploadError('Target AEM instance must have direct binary upload enabled', ErrorCodes.NOT_SUPPORTED);
             } else if (!Array.isArray(initiateResponse.files) || (initiateResponse.files.length !== assets.length)) {
                 throw Error(`'files' field incomplete in initiateUpload response (expected files: ${assets.length}): ${JSON.stringify(initiateResponse)}`);
             } else if (typeof initiateResponse.completeURI !== "string") {

--- a/test/functions/aeminitiateupload.test.js
+++ b/test/functions/aeminitiateupload.test.js
@@ -442,7 +442,7 @@ describe("AEMInitiateUpload", () => {
         it("files missing", async () => {
             await tryInvalidInitiateUploadResponse({
                 completeURI: "/path/to.completeUpload.json"
-            }, "'files' field missing in initiateUpload response: {\"completeURI\":\"/path/to.completeUpload.json\"}");
+            }, "Target AEM instance must have direct binary upload enabled");
         });
         it("files length mismatch", async () => {
             await tryInvalidInitiateUploadResponse({


### PR DESCRIPTION
## Description

The http transfer process is not expected to work on an AEM instance that is not configured with direct binary upload.

The library currently throw an error along the lines of `Error: 'files' field missing in initiateUpload response: [{"fileName”:”ascas-rasf-Pinouts.zip"}]`. This can be confusing to clients and doesn't provide helpful information about a known use case. This PR changes the error message to indicate that the target of the upload does not support direct binary upload.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
