### PR TITLE
Allow parenthesis in asset names

### DIFF
--- a/e2e/e2eutils.js
+++ b/e2e/e2eutils.js
@@ -53,3 +53,12 @@ module.exports.getAuthorizationHeader = function() {
 
     throw new Error('Either BASIC_AUTH or LOGIN_TOKEN env variable must be set');
 };
+
+/**
+ * Retrieves an ID that can be used to uniquely identify an execution of a test.
+ *
+ * @returns {string} Identifier for the test.
+ */
+module.exports.getUniqueTestId = function() {
+    return `node-httptransfer_aem-e2e_${new Date().getTime()}`;
+};

--- a/lib/functions/failunsupportedassets.js
+++ b/lib/functions/failunsupportedassets.js
@@ -34,6 +34,12 @@ class FailUnsupportedAssets extends AsyncGeneratorFunction {
                     throw new UnsupportedFileUploadError("Empty file");
                 }
 
+                // initiate upload rejects these characters
+                const filename = transferAsset.target.filename;
+                if (filename.match(/[[\]{}&:\\?#|*%]/g)) {
+                    throw new UnsupportedFileUploadError(`Filename '${filename}' has unsupported characters`);
+                }
+
                 yield transferAsset;
             } catch (error) {
                 controller.notifyError(this.name, error, transferAsset);

--- a/lib/functions/failunsupportedassets.js
+++ b/lib/functions/failunsupportedassets.js
@@ -34,12 +34,6 @@ class FailUnsupportedAssets extends AsyncGeneratorFunction {
                     throw new UnsupportedFileUploadError("Empty file");
                 }
 
-                // initiate upload rejects these characters
-                const filename = transferAsset.target.filename;
-                if (filename.match(/[[\]{}&:\\?#|*()%]/g)) {
-                    throw new UnsupportedFileUploadError(`Filename '${filename}' has unsupported characters`);
-                }
-
                 yield transferAsset;
             } catch (error) {
                 controller.notifyError(this.name, error, transferAsset);

--- a/test/functions/failunsupportedassets.test.js
+++ b/test/functions/failunsupportedassets.test.js
@@ -61,7 +61,7 @@ describe("FailUnsupportedAssets", () => {
             error: "File cannot be uploaded: Empty file"
         }]);
     });
-    it("unsupported-parenthesis", async function() {
+    it("supported-parenthesis", async function() {
         const source = new Asset("file://path/to/file.png");
         const target = new Asset("https://host/path/to/(upload).png");
         const inputAsset = new TransferAsset(source, target, {
@@ -72,12 +72,6 @@ describe("FailUnsupportedAssets", () => {
         for await (const transferAsset of failUnsupportedAssets.execute([ inputAsset ], controller)) {
             assert.deepStrictEqual(transferAsset, inputAsset);
         }
-        assert.deepStrictEqual(controller.notifications, [{
-            eventName: "error",
-            functionName: "FailUnsupportedAssets",
-            props: undefined,
-            transferItem: inputAsset,
-            error: "File cannot be uploaded: Filename '(upload).png' has unsupported characters"
-        }]);
+        assert.deepStrictEqual(controller.notifications, []);
     });
 });

--- a/test/functions/failunsupportedassets.test.js
+++ b/test/functions/failunsupportedassets.test.js
@@ -61,6 +61,25 @@ describe("FailUnsupportedAssets", () => {
             error: "File cannot be uploaded: Empty file"
         }]);
     });
+    it("unsupported-brackets", async function() {
+        const source = new Asset("file://path/to/file.png");
+        const target = new Asset("https://host/path/to/[upload].png");
+        const inputAsset = new TransferAsset(source, target, {
+            metadata: new AssetMetadata(undefined, "image/png", 1)
+        });
+        const failUnsupportedAssets = new FailUnsupportedAssets;
+        const controller = new ControllerMock;
+        for await (const transferAsset of failUnsupportedAssets.execute([ inputAsset ], controller)) {
+            assert.deepStrictEqual(transferAsset, inputAsset);
+        }
+        assert.deepStrictEqual(controller.notifications, [{
+            eventName: "error",
+            functionName: "FailUnsupportedAssets",
+            props: undefined,
+            transferItem: inputAsset,
+            error: "File cannot be uploaded: Filename '[upload].png' has unsupported characters"
+        }]);
+    });
     it("supported-parenthesis", async function() {
         const source = new Asset("file://path/to/file.png");
         const target = new Asset("https://host/path/to/(upload).png");


### PR DESCRIPTION
## Description

Updates the list of characters that are rejected by the module so that parenthesis are now allowed.

I also added a new e2e test that will verify that a single asset with invalid characters in its name doesn't fail the entire upload.

Fixes #76 

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
