### PR TITLE
NUI-1674 refactor bulk upload and multipart upload api to adapt to asset-compute-pipeline use

### DIFF
--- a/e2e/blocktransfer.test.js
+++ b/e2e/blocktransfer.test.js
@@ -24,7 +24,7 @@ const {
 } = require("../lib");
 const {
     getBlobUrl,
-    getAuthorizationHeader
+    // getAuthorizationHeader
 } = require("./e2eutils");
 
 /***

--- a/lib/aempartsize.js
+++ b/lib/aempartsize.js
@@ -57,7 +57,7 @@ function calculatePartSize(numUrls, fileSize, minPartSize, maxPartSize, preferre
     // Throw an error if the required part size is too large
     let partSize = Math.max(Math.ceil(fileSize / numUrls), minPartSize);
     if (partSize > maxPartSize) {
-        throw Error(`Too large to upload: ${fileSize} bytes, maxPartSize: ${maxPartSize} bytes, numUploadURIs: ${numUrls}`);
+        throw Error(`File is too large to upload: ${fileSize} bytes, maxPartSize: ${maxPartSize} bytes, numUploadURIs: ${numUrls}`);
     }
 
     // Override using the preferredPartSize, clamp its value to ensure that its at least

--- a/lib/block/blockupload.js
+++ b/lib/block/blockupload.js
@@ -39,8 +39,6 @@ const { AssetMultipart } = require("../asset/assetmultipart");
 const DEFAULT_MAX_CONCURRENCY = 8;
 // Defaul part size is 10mb
 const DEFAULT_PART_SIZE = 10 * 1024 * 1024;
-// Default retry max count
-const DEFAULT_RETRY_COUNT = 5;
 
 /**
  * Generate Block upload transfer assets
@@ -129,10 +127,6 @@ class BlockUpload extends EventEmitter {
     async uploadFiles(options = {}) {
         const preferredPartSize = options.preferredPartSize || DEFAULT_PART_SIZE;
         const maxConcurrent = options.maxConcurrent || DEFAULT_MAX_CONCURRENCY;
-
-        if (!options.retryMaxCount) {
-            options.retryMaxCount = DEFAULT_RETRY_COUNT;
-        }
 
         const controller = new TransferController();
         controller.on(TransferEvents.TRANSFER, transferEvent => {

--- a/lib/block/blockupload.js
+++ b/lib/block/blockupload.js
@@ -84,8 +84,8 @@ async function* generateBlockUploadTransfer(options) {
         });
 
         const uploadURIs = uploadFile.fileUrl;
-        const minPartSize = uploadFile.minPartSize || 10;
         const maxPartSize = uploadFile.maxPartSize;
+        const minPartSize = uploadFile.minPartSize || Math.min(10, maxPartSize); // maxPartSize must be defined
         
         if(typeof uploadURIs === 'object' && Array.isArray(uploadURIs)) {
             transferAsset.multipartTarget = new AssetMultipart(
@@ -117,8 +117,8 @@ class BlockUpload extends EventEmitter {
      * @typedef {Object} BlockUploadOptions
      * @property {UploadFile[]} uploadFiles List of files that will be uploaded to the target URL. 
      * @property {*} headers HTTP headers that will be included in each request sent to AEM
-     * @property {Boolean} concurrent If true, multiple files in the supplied list of upload files will transfer simultaneously. If false, only one file will transfer at a time, and the next file will not begin transferring until the current file finishes.
-     * @property {Number} maxConcurrent Maximum number of concurrent HTTP requests that are allowed
+     * @property {Boolean} concurrent If true, multiple files in the supplied list of upload files will transfer simultaneously. If false, only one file will transfer at a time, and the next file will not begin transferring until the current file finishes. (currently not in use)
+     * @property {Number} maxConcurrent Maximum number of concurrent HTTP requests that are allowed. If set to 1, only one chunk will transfer at a time, and the next chunk will not begin transferring until the current file finishes.
      * @property {Number} [preferredPartSize] Preferred part size
      */
     /**
@@ -128,15 +128,11 @@ class BlockUpload extends EventEmitter {
      */
     async uploadFiles(options = {}) {
         const preferredPartSize = options.preferredPartSize || DEFAULT_PART_SIZE;
-        const maxConcurrent = (options.concurrent && options.maxConcurrent) || DEFAULT_MAX_CONCURRENCY;
-        const retryOptions = {
-            retryMaxCount: options.retryCount || DEFAULT_RETRY_COUNT,
-            timeout: options.timeout,
-            retryAllErrors: options.retryAllErrors,
-            retryMaxDuration: options.retryMaxDuration,
-            retryInitialDelay: options.retryInitialDelay,
-            retryBackoff: options.retryBackoff,
-        };
+        const maxConcurrent = options.maxConcurrent || DEFAULT_MAX_CONCURRENCY;
+
+        if (!options.retryMaxCount) {
+            options.retryMaxCount = DEFAULT_RETRY_COUNT;
+        }
 
         const controller = new TransferController();
         controller.on(TransferEvents.TRANSFER, transferEvent => {
@@ -178,7 +174,7 @@ class BlockUpload extends EventEmitter {
             const pipeline = new Pipeline(
                 new FailUnsupportedAssets(),
                 new CreateTransferParts({ preferredPartSize }),
-                new MapConcurrent(new Transfer(randomFileAccess, retryOptions), { maxConcurrent }),
+                new MapConcurrent(new Transfer(randomFileAccess, options), { maxConcurrent }),
                 new JoinTransferParts,
                 new CloseFiles(randomFileAccess),
             );

--- a/lib/file.js
+++ b/lib/file.js
@@ -16,9 +16,9 @@ const filterObject = require('filter-obj');
 const fs = require('fs');
 const path = require('path');
 const { downloadStream, uploadStream } = require('./stream');
-const { createReadStream, createWriteStream, getFileStats } = require('./util');
+const { createReadStream, createWriteStream, getFileStats, isPositiveNumber } = require('./util');
 const { retry } = require('./retry');
-const { HttpStreamError } = require('./error');
+const { HttpStreamError, IllegalArgumentError } = require('./error');
 const { BlockDownload } = require('./block/blockdownload');
 const { BlockUpload } = require('./block/blockupload');
 
@@ -128,6 +128,19 @@ async function downloadFileConcurrently(url, filepath, options) {
 }
 
 /**
+ * @typedef {Object} UploadFileOptions
+ *
+ * @property {String} [method] Optional HTTP method (defaults to 'PUT')
+ * @property {Number} [timeout] Optional socket timeout
+ * @property {Object} [headers] Optional override of request headers
+ * @property {Number} [retryMaxDuration=60000] time to retry until throwing an error (ms)
+ * @property {Number} [retryMaxCount=5] time to retry until throwing an error (ms)
+ * @property {Number} [retryInterval=100] time between retries, used by exponential backoff (ms)
+ * @property {Boolean} [retryEnabled=true] retry on failure enabled
+ * @property {Boolean} [retryAllErrors=false] whether or not to retry on all http error codes or just >=500
+ * @property {Number} [maxConcurrent] Optional concurrent amount.
+ */
+/**
  * Upload file using multiple simultaneous transfers
  * Throws the first unrecoverable error if unsuccessful, all others are logged
  * @param {String|URL} url Location to upload (e.g. presigned URL) 
@@ -138,6 +151,15 @@ async function downloadFileConcurrently(url, filepath, options) {
 async function uploadFileConcurrently(filepath, url, options) {
     // options contains header information
     const { size } = await getFileStats(filepath);
+
+    // extract upload options
+    const uploadOptions = filterObject(
+        options || {},
+        [ 'method', 'timeout', 'headers', 'maxConcurrent', 'concurrent',
+            'retryMaxDuration', 'retryInterval', 'retryEnabled',
+            'retryAllErrors', 'retryMaxCount', 'preferredPartSize' ]
+    );
+
     const uploader = new BlockUpload();
     return uploader.uploadFiles({
         uploadFiles: [
@@ -147,31 +169,74 @@ async function uploadFileConcurrently(filepath, url, options) {
                 fileSize : size
             }
         ],
-        ...options
+        ...uploadOptions
     });
 }
 
 /**
+ * @typedef {Object} UploadAEMMultipartOptions
+ *
+ * @property {String} [method] Optional HTTP method (defaults to 'PUT')
+ * @property {Number} [timeout] Optional socket timeout
+ * @property {Object} [headers] Optional override of request headers
+ * @property {Number} [retryMaxDuration=60000] time to retry until throwing an error (ms)
+ * @property {Number} [retryMaxCount=5] time to retry until throwing an error (ms)
+ * @property {Number} [retryInterval=100] time between retries, used by exponential backoff (ms)
+ * @property {Boolean} [retryEnabled=true] retry on failure enabled
+ * @property {Boolean} [retryAllErrors=false] whether or not to retry on all http error codes or just >=500
+ * @property {Number} [preferredPartSize] Optional custom preferred part size. Might be adjusted depending on the target.
+ * @property {Number} [maxConcurrent] Optional concurrent amount.
+ */
+/**
+ * @typedef {Object} UploadAEMMultipartTarget
+ *
+ * @property {String[]} urls URLs
+ * @property {Number} [maxPartSize] Maximum size of each part
+ */
+/**
  * Upload multi part file using multiple simultaneous transfers
  * Throws the first unrecoverable error if unsuccessful, all others are logged
- * @param {Array.<String|URL>} urls Array of url locations for multipart upload (e.g. presigned URL) 
+ * @param {UploadAEMMultipartTarget} target Target urls
  * @param {String} filepath Path to locally saved file
- * @param {UploadFileOptions} options Additional options such as headers, retry features, etc 
+ * @param {UploadAEMMultipartOptions} options Additional options such as headers, retry features, etc 
  * @returns {Promise} resolves when upload completes
  */
-async function uploadMultiPartFileConcurrently(filepath, urls, options) {
-    // options contains header information
+async function uploadMultiPartFileConcurrently(filepath, target, options={}) {
+    // fail fast, keep error handling the same as older, non-concurrent function
+    if (!target) {
+        throw new IllegalArgumentError('target not provided', target);
+    } else if (!target.urls || target.urls.length === 0) {
+        throw new IllegalArgumentError('\'target.urls\' but be a non-empty array', target.urls);
+    } else if (!isPositiveNumber(target.maxPartSize)) {
+        throw new IllegalArgumentError('\'target.maxPartSize\' must be a positive number', target.maxPartSize);
+    }
+
+    // Calculate the partSize based on the number of urls
     const { size } = await getFileStats(filepath);
+
+    // to stay backwards compatible with older `uploadAEMMultipartFile` that uses `partSize`
+    options.preferredPartSize = options.partSize? options.partSize: options.preferredPartSize;
+
+    // extract upload options
+    const uploadOptions = filterObject(
+        options || {},
+        [ 'method', 'timeout', 'headers', 'maxConcurrent', 'concurrent',
+            'retryMaxDuration', 'retryInterval', 'retryEnabled',
+            'retryAllErrors', 'retryMaxCount', 'preferredPartSize' ]
+    );
+
     const uploader = new BlockUpload();
     return uploader.uploadFiles({
         uploadFiles: [
             {
-                fileUrl : urls,
+                fileUrl : target.urls,
                 filePath : filepath,
-                fileSize : size
+                fileSize : size,
+                maxPartSize: target.maxPartSize,
+                multipartHeaders: target.multipartHeaders
             }
         ],
-        ...options
+        ...uploadOptions
     });
 }
 

--- a/lib/functions/transfer.js
+++ b/lib/functions/transfer.js
@@ -70,26 +70,36 @@ class Transfer extends AsyncGeneratorFunction {
                 if (isFileProtocol(transferPart.source.url) && targetUrl) {
                     const buf = await this.randomFileAccess.read(transferPart.source.url, contentRange);
                     await retry(async () => {
-                        await issuePut(targetUrl, {
+                        const requestOptions = {
                             body: buf,
                             timeout: this.options && this.options.timeout,
                             headers: Object.assign({
                                 [HTTP.HEADER.CONTENT_LENGTH]: buf.length,
                                 [HTTP.HEADER.CONTENT_TYPE]: transferPart.metadata.contentType
                             }, transferPart.targetHeaders)
-                        });    
+                        };
+                        // to stay backwards compatible, AEMmultiPart upload supports methods `POST` instead of `PUT`
+                        if (this.options && this.options.method) {
+                            requestOptions.method = this.options.method;
+                        }
+                        await issuePut(targetUrl, requestOptions);
                     }, this.options);
                 } else if (transferPart.source.blob && targetUrl) {
                     const blob = transferPart.source.blob.slice(contentRange.low, contentRange.high + 1);
                     await retry(async () => {
-                        await issuePut(targetUrl, {
+                        const requestOptions = {
                             body: blob,
                             timeout: this.options && this.options.timeout,
                             headers: Object.assign({
                                 [HTTP.HEADER.CONTENT_LENGTH]: blob.size,
                                 [HTTP.HEADER.CONTENT_TYPE]: transferPart.metadata.contentType
                             }, transferPart.targetHeaders)
-                        });
+                        };
+                        // to stay backwards compatible, AEMmultiPart upload supports methods `POST` instead of `PUT`
+                        if (this.options && this.options.method) {
+                            requestOptions.method = this.options.method;
+                        }
+                        await issuePut(targetUrl, requestOptions);
                     }, this.options);
                 } else if (targetUrl && isFileProtocol(targetUrl) && transferPart.source.url) {
                     await retry(async () => {

--- a/lib/index.js
+++ b/lib/index.js
@@ -13,7 +13,7 @@
 'use strict';
 
 const { downloadStream, uploadStream, transferStream } = require('./stream');
-const { downloadFile, uploadFile, downloadFileConcurrently } = require('./file');
+const { downloadFile, uploadFile, downloadFileConcurrently, uploadFileConcurrently, uploadMultiPartFileConcurrently } = require('./file');
 const { uploadAEMMultipartFile } = require('./aemmultipart');
 const { getResourceHeaders } = require('./headers');
 const { AEMUpload } = require("./aem/aemupload");
@@ -25,6 +25,8 @@ module.exports = {
     downloadStream, uploadStream, transferStream,
     downloadFile, uploadFile,
     downloadFileConcurrently,
+    uploadFileConcurrently,
+    uploadMultiPartFileConcurrently,
     uploadAEMMultipartFile,
     getResourceHeaders,
     AEMUpload,

--- a/test/block/blockdownload.test.js
+++ b/test/block/blockdownload.test.js
@@ -15,11 +15,7 @@
 'use strict';
 
 const assert = require('assert');
-const fs = require('fs').promises;
 const nock = require('nock');
-const Path = require('path');
-const { BlockUpload } = require('../../lib/block/blockdownload');
-const { Blob } = require('blob-polyfill');
 
 describe('Block Download', function() {
     afterEach(async function () {

--- a/test/block/blockupload.test.js
+++ b/test/block/blockupload.test.js
@@ -67,10 +67,7 @@ describe('Block Upload', function() {
             uploadFiles: [{
                 fileUrl: targetUrl,
                 filePath: testFile,
-                fileSize: 15,
-                multipartHeaders: { partHeader: 'test' },
-                minPartSize: 10,
-                maxPartSize: 25
+                fileSize: 15
             }],
             headers: {
                 // Asset Compute passes through content-type header
@@ -78,7 +75,6 @@ describe('Block Upload', function() {
             },
             concurrent: true,
             maxConcurrent: 5,
-            preferredPartSize: 7
         });
 
         try {

--- a/test/file.test.js
+++ b/test/file.test.js
@@ -18,7 +18,8 @@ const assert = require('assert');
 const fs = require('fs').promises;
 const nock = require('nock');
 const path = require('path');
-const { downloadFile, uploadFile, uploadFileConcurrently } = require('../lib/file');
+const crypto = require('crypto');
+const { downloadFile, uploadFile, uploadFileConcurrently, uploadMultiPartFileConcurrently } = require('../lib/file');
 const { testSetResponseBodyOverride, testHasResponseBodyOverrides } = require('../lib/fetch');
 const { createErrorReadable } = require('./streams');
 
@@ -552,3 +553,719 @@ describe('file', function() {
         }).timeout(20000);
     });
 });
+
+describe('multipart upload concurrently', function () {
+    describe('upload', function () {
+        afterEach(async function () {
+            assert.ok(!testHasResponseBodyOverrides(), 'ensure no response body overrides are in place');
+            assert.ok(nock.isDone(), 'check if all nocks have been used');
+            nock.cleanAll();
+        });
+        it('no target', async function () {
+            await fs.writeFile('test-transfer-file-1.dat', 'hello world 123', 'utf8');
+
+            try {
+                await uploadMultiPartFileConcurrently('test-transfer-file-1.dat');
+            } catch (e) {
+                assert.strictEqual(e.message, 'target not provided: undefined');
+            }
+
+            try {
+                await fs.unlink('test-transfer-file-1.dat');
+            } catch (e) { // ignore cleanup failures
+                console.log(e);
+            }
+        });
+        it('no target urls', async function () {
+            await fs.writeFile('test-transfer-file-2.dat', 'hello world 123', 'utf8');
+
+            try {
+                await uploadMultiPartFileConcurrently('test-transfer-file-2.dat', {});
+            } catch (e) {
+                assert.strictEqual(e.message, '\'target.urls\' but be a non-empty array: undefined');
+            }
+
+            try {
+                await fs.unlink('test-transfer-file-2.dat');
+            } catch (e) { // ignore cleanup failures
+                console.log(e);
+            }
+        });
+        it('max-part-size is missing', async function () {
+            await fs.writeFile('test-transfer-file-3.dat', 'hello world 123', 'utf8');
+
+            try {
+                await uploadMultiPartFileConcurrently('test-transfer-file-3.dat', {
+                    urls: [
+                        'http://test-status-201/path/to/file-1.ext',
+                    ]
+                });
+            } catch (e) {
+                assert.strictEqual(e.message, '\'target.maxPartSize\' must be a positive number: undefined');
+            }
+
+            try {
+                await fs.unlink('test-transfer-file-3.dat');
+            } catch (e) { // ignore cleanup failures
+                console.log(e);
+            }
+        });
+        it('status-201-1url', async function () {
+            await fs.writeFile('test-transfer-file-4.dat', 'hello world 123', 'utf8');
+
+            nock('http://test-status-201')
+                .matchHeader('content-length', 15)
+                .put('/path/to/file-1.ext', 'hello world 123')
+                .reply(201);
+
+            await uploadMultiPartFileConcurrently('test-transfer-file-4.dat', {
+                urls: [
+                    'http://test-status-201/path/to/file-1.ext'
+                ],
+                maxPartSize: 15
+            });
+
+            try {
+                await fs.unlink('test-transfer-file-4.dat');
+            } catch (e) { // ignore cleanup failures
+                console.log(e);
+            }
+        });
+        it('status-201-2urls', async function () {
+            await fs.writeFile('test-transfer-file-5.dat', 'hello world 123', 'utf8');
+
+            nock('http://test-status-201')
+                .matchHeader('content-length', 8)
+                .put('/path/to/file-1.ext', 'hello wo')
+                .reply(201);
+            nock('http://test-status-201')
+                .matchHeader('content-length', 7)
+                .put('/path/to/file-2.ext', 'rld 123')
+                .reply(201);
+
+            await uploadMultiPartFileConcurrently('test-transfer-file-5.dat', {
+                urls: [
+                    'http://test-status-201/path/to/file-1.ext',
+                    'http://test-status-201/path/to/file-2.ext'
+                ],
+                maxPartSize: 8
+            });
+
+            try {
+                await fs.unlink('test-transfer-file-5.dat');
+            } catch (e) { // ignore cleanup failures
+                console.log(e);
+            }
+        });
+
+        it('status-201-2urls binary', async function () {
+            const data = crypto.randomBytes(100);
+
+            await fs.writeFile('test-binary.dat', data);
+
+            nock('http://test-status-201')
+                .matchHeader('content-length', 50)
+                .put('/path/to/file-1.ext', data.slice(0, 50))
+                .reply(201);
+            nock('http://test-status-201')
+                .matchHeader('content-length', 50)
+                .put('/path/to/file-2.ext', data.slice(50))
+                .reply(201);
+
+            await uploadMultiPartFileConcurrently('test-binary.dat', {
+                urls: [
+                    'http://test-status-201/path/to/file-1.ext',
+                    'http://test-status-201/path/to/file-2.ext'
+                ],
+                maxPartSize: 50
+            });
+
+            try {
+                await fs.unlink('test-binary.dat');
+            } catch (e) { // ignore cleanup failures
+                console.log(e);
+            }
+        });
+
+        it('status-201-2urls-maxpartjustenough', async function () {
+            await fs.writeFile('test-transfer-file-6.dat', 'hello world 123', 'utf8');
+
+            nock('http://test-status-201')
+                .matchHeader('content-length', 8)
+                .put('/path/to/file-1.ext', 'hello wo')
+                .reply(201);
+            nock('http://test-status-201')
+                .matchHeader('content-length', 7)
+                .put('/path/to/file-2.ext', 'rld 123')
+                .reply(201);
+
+            await uploadMultiPartFileConcurrently('test-transfer-file-6.dat', {
+                maxPartSize: 8,
+                urls: [
+                    'http://test-status-201/path/to/file-1.ext',
+                    'http://test-status-201/path/to/file-2.ext'
+                ]
+            });
+
+            try {
+                await fs.unlink('test-transfer-file-6.dat');
+            } catch (e) { // ignore cleanup failures
+                console.log(e);
+            }
+        });
+        it('status-201-2urls-maxparttoosmall', async function () {
+            await fs.writeFile('test-transfer-file-7.dat', 'hello world 123', 'utf8');
+
+            try {
+                await uploadMultiPartFileConcurrently('test-transfer-file-7.dat', {
+                    maxPartSize: 7,
+                    urls: [
+                        'http://test-status-201/path/to/file-1.ext',
+                        'http://test-status-201/path/to/file-2.ext'
+                    ]
+                });
+                assert.fail('expected to fail');
+            } catch (e) {
+                assert.ok(e.message.includes('Too large to upload'));
+            }
+
+            try {
+                await fs.unlink('test-transfer-file-7.dat');
+            } catch (e) { // ignore cleanup failures
+                console.log(e);
+            }
+        });
+        it('status-201-10urls-fits2', async function () {
+            await fs.writeFile('test-transfer-file-9.dat', 'hello world 123', 'utf8');
+
+            nock('http://test-status-201')
+                .matchHeader('content-length', 8)
+                .put('/path/to/file-1.ext', 'hello wo')
+                .reply(201);
+            nock('http://test-status-201')
+                .matchHeader('content-length', 7)
+                .put('/path/to/file-2.ext', 'rld 123')
+                .reply(201);
+
+            await uploadMultiPartFileConcurrently('test-transfer-file-9.dat', {
+                maxPartSize: 8,
+                urls: [
+                    'http://test-status-201/path/to/file-1.ext',
+                    'http://test-status-201/path/to/file-2.ext',
+                    'http://test-status-201/path/to/file-3.ext',
+                    'http://test-status-201/path/to/file-4.ext',
+                    'http://test-status-201/path/to/file-5.ext',
+                    'http://test-status-201/path/to/file-6.ext',
+                    'http://test-status-201/path/to/file-7.ext',
+                    'http://test-status-201/path/to/file-8.ext',
+                    'http://test-status-201/path/to/file-9.ext',
+                    'http://test-status-201/path/to/file-10.ext',
+                ]
+            });
+
+            try {
+                await fs.unlink('test-transfer-file-9.dat');
+            } catch (e) { // ignore cleanup failures
+                console.log(e);
+            }
+        });
+       
+        it('status-201-2urls-preferred-smallermaxsize', async function () {
+            await fs.writeFile('test-transfer-file-15.dat', 'hello world 123', 'utf8');
+
+            // minPartSize smaller than preferred has no effect
+            nock('http://test-status-201')
+                .matchHeader('content-length', 8)
+                .put('/path/to/file-1.ext', 'hello wo')
+                .reply(201);
+            nock('http://test-status-201')
+                .matchHeader('content-length', 7)
+                .put('/path/to/file-2.ext', 'rld 123')
+                .reply(201);
+
+            await uploadMultiPartFileConcurrently('test-transfer-file-15.dat', {
+                maxPartSize: 8,
+                urls: [
+                    'http://test-status-201/path/to/file-1.ext',
+                    'http://test-status-201/path/to/file-2.ext'
+                ]
+            }, {
+                partSize: 9,
+            });
+
+            try {
+                await fs.unlink('test-transfer-file-15.dat');
+            } catch (e) { // ignore cleanup failures
+                console.log(e);
+            }
+        });
+        it('status-201-2urls-preferred-largermaxsize', async function () {
+            await fs.writeFile('test-transfer-file-16.dat', 'hello world 123', 'utf8');
+
+            // preferred is limited on the lower-bound by minPartSize, so
+            // the picked part size is the minPartSize
+            nock('http://test-status-201')
+                .matchHeader('content-length', 8)
+                .put('/path/to/file-1.ext', 'hello wo')
+                .reply(201);
+            nock('http://test-status-201')
+                .matchHeader('content-length', 7)
+                .put('/path/to/file-2.ext', 'rld 123')
+                .reply(201);
+
+            await uploadMultiPartFileConcurrently('test-transfer-file-16.dat', {
+                maxPartSize: 8,
+                urls: [
+                    'http://test-status-201/path/to/file-1.ext',
+                    'http://test-status-201/path/to/file-2.ext'
+                ]
+            }, {
+                partSize: 7,
+            });
+
+            try {
+                await fs.unlink('test-transfer-file-16.dat');
+            } catch (e) { // ignore cleanup failures
+                console.log(e);
+            }
+        });
+        it('status-404-url1', async function () {
+            await fs.writeFile('test-transfer-file-17.dat', 'hello world 123', 'utf8');
+
+            try {
+                nock('http://test-status-404')
+                    .matchHeader('content-length', 8)
+                    .put('/path/to/file-1.ext', 'hello wo')
+                    .reply(404);
+                nock('http://test-status-404')
+                    .matchHeader('content-length', 7)
+                    .put('/path/to/file-2.ext', 'rld 123')
+                    .reply(200);
+
+                await uploadMultiPartFileConcurrently('test-transfer-file-17.dat', {
+                    urls: [
+                        'http://test-status-404/path/to/file-1.ext',
+                        'http://test-status-404/path/to/file-2.ext'
+                    ],
+                    maxPartSize: 8,
+                });
+            } catch (e) {
+                assert.ok(e.message.includes('PUT'));
+                assert.ok(e.message.includes('failed with status 404'));
+            }
+
+            try {
+                await fs.unlink('test-transfer-file-17.dat');
+            } catch (e) { // ignore cleanup failures
+                console.log(e);
+            }
+        });
+        it('status-404-url1-concurrency-1', async function () {
+            await fs.writeFile('test-transfer-file-17.dat', 'hello world 123', 'utf8');
+
+            try {
+                nock('http://test-status-404')
+                    .matchHeader('content-length', 3)
+                    .put('/path/to/file-1.ext', 'hel')
+                    .reply(404);
+
+                nock('http://test-status-404')
+                    .matchHeader('content-length', 3)
+                    .put('/path/to/file-2.ext', 'lo ')
+                    .reply(200);
+                nock('http://test-status-404')
+                    .matchHeader('content-length', 3)
+                    .put('/path/to/file-3.ext', 'wor')
+                    .reply(200);
+                // TODO, look into why this is happening
+                // first URL fails first
+                // two (out of 4 remaining) urls get executed before the filter function causes the request to end due to an error
+
+
+                await uploadMultiPartFileConcurrently('test-transfer-file-17.dat', {
+                    urls: [
+                        'http://test-status-404/path/to/file-1.ext',
+                        'http://test-status-404/path/to/file-2.ext',
+                        'http://test-status-404/path/to/file-3.ext',
+                        'http://test-status-404/path/to/file-4.ext',
+                        'http://test-status-404/path/to/file-5.ext',
+                    ],
+                    maxPartSize: 3,
+                }, {
+                    maxConcurrent: 1
+                });
+            } catch (e) {
+                assert.ok(e.message.includes('PUT'));
+                assert.ok(e.message.includes('failed with status 404'));
+            }
+
+            try {
+                await fs.unlink('test-transfer-file-17.dat');
+            } catch (e) { // ignore cleanup failures
+                console.log(e);
+            }
+        });
+        it('status-404-url1-concurrency-5', async function () {
+            await fs.writeFile('test-transfer-file-17.dat', 'hello world 123', 'utf8');
+
+            try {
+                nock('http://test-status-404')
+                    .matchHeader('content-length', 3)
+                    .put('/path/to/file-1.ext', 'hel')
+                    .reply(404);
+                nock('http://test-status-404')
+                    .matchHeader('content-length', 3)
+                    .put('/path/to/file-2.ext', 'lo ')
+                    .reply(200);
+                nock('http://test-status-404')
+                    .matchHeader('content-length', 3)
+                    .put('/path/to/file-3.ext', 'wor')
+                    .reply(200);
+                nock('http://test-status-404')
+                    .matchHeader('content-length', 3)
+                    .put('/path/to/file-4.ext', 'ld ')
+                    .reply(200);
+                nock('http://test-status-404')
+                    .matchHeader('content-length', 3)
+                    .put('/path/to/file-5.ext', '123')
+                    .reply(200);
+                // since the 5 chunk requests happen concurrently, if one fails, the rest still continue
+
+
+                await uploadMultiPartFileConcurrently('test-transfer-file-17.dat', {
+                    urls: [
+                        'http://test-status-404/path/to/file-1.ext',
+                        'http://test-status-404/path/to/file-2.ext',
+                        'http://test-status-404/path/to/file-3.ext',
+                        'http://test-status-404/path/to/file-4.ext',
+                        'http://test-status-404/path/to/file-5.ext',
+                    ],
+                    maxPartSize: 3,
+                }, {
+                    maxConcurrent: 5
+                });
+            } catch (e) {
+                assert.ok(e.message.includes('PUT'));
+                assert.ok(e.message.includes('failed with status 404'));
+            }
+
+            try {
+                await fs.unlink('test-transfer-file-17.dat');
+            } catch (e) { // ignore cleanup failures
+                console.log(e);
+            }
+        });
+        it('status-404-url2', async function () {
+            await fs.writeFile('test-transfer-file-18.dat', 'hello world 123', 'utf8');
+
+            try {
+                nock('http://test-status-404')
+                    .matchHeader('content-length', 8)
+                    .put('/path/to/file-1.ext', 'hello wo')
+                    .reply(201);
+                nock('http://test-status-404')
+                    .matchHeader('content-length', 7)
+                    .put('/path/to/file-2.ext', 'rld 123')
+                    .reply(404);
+
+                await uploadMultiPartFileConcurrently('test-transfer-file-18.dat', {
+                    urls: [
+                        'http://test-status-404/path/to/file-1.ext',
+                        'http://test-status-404/path/to/file-2.ext'
+                    ],
+                    maxPartSize: 8,
+                });
+            } catch (e) {
+                assert.ok(e.message.includes('PUT'));
+                assert.ok(e.message.includes('failed with status 404'));
+            }
+
+            try {
+                await fs.unlink('test-transfer-file-18.dat');
+            } catch (e) { // ignore cleanup failures
+                console.log(e);
+            }
+        });
+        it('method-post', async function () {
+            await fs.writeFile('test-transfer-file-19.dat', 'hello world 123', 'utf8');
+
+            nock('http://test-method-post')
+                .matchHeader('content-length', 8)
+                .post('/path/to/file-1.ext', 'hello wo')
+                .reply(201);
+            nock('http://test-method-post')
+                .matchHeader('content-length', 7)
+                .post('/path/to/file-2.ext', 'rld 123')
+                .reply(201);
+
+            await uploadMultiPartFileConcurrently('test-transfer-file-19.dat', {
+                urls: [
+                    'http://test-method-post/path/to/file-1.ext',
+                    'http://test-method-post/path/to/file-2.ext'
+                ],
+                maxPartSize: 8,
+            }, {
+                method: 'POST'
+            });
+
+            try {
+                await fs.unlink('test-transfer-file-19.dat');
+            } catch (e) { // ignore cleanup failures
+                console.log(e);
+            }
+        });
+        it('timeout-error-1', async function () {
+            await fs.writeFile('test-transfer-file-20.dat', 'hello world 123', 'utf8');
+
+            try {
+                nock('http://timeout-error')
+                    .matchHeader('content-length', 8)
+                    .put('/path/to/file-1.ext', 'hello wo')
+                    .delayConnection(700)
+                    .reply(201);
+                nock('http://timeout-error')
+                    .matchHeader('content-length', 7)
+                    .put('/path/to/file-2.ext', 'rld 123')
+                    .reply(201);
+
+                await uploadMultiPartFileConcurrently('test-transfer-file-20.dat', {
+                    urls: [
+                        'http://timeout-error/path/to/file-1.ext',
+                        'http://timeout-error/path/to/file-2.ext'
+                    ],
+                    maxPartSize: 8,
+                }, {
+                    timeout: 200,
+                    retryEnabled: false
+                });
+
+                assert.fail('failure expected');
+            } catch (e) {
+                assert.ok(e.message.includes('PUT'));
+                assert.ok(e.message.includes('connect failed'));
+                assert.ok(e.message.includes('network timeout'));
+            }
+
+            try {
+                await fs.unlink('test-transfer-file-20.dat');
+            } catch (e) { // ignore cleanup failures
+                console.log(e);
+            }
+        });
+
+        it('timeout-error-1-no-retry', async function () {
+            await fs.writeFile('test-transfer-file-20.dat', 'hello world 123', 'utf8');
+
+            try {
+                nock('http://timeout-error')
+                    .matchHeader('content-length', 8)
+                    .put('/path/to/file-1.ext', 'hello wo')
+                    .delayConnection(500)
+                    .reply(201);
+                nock('http://timeout-error')
+                    .matchHeader('content-length', 7)
+                    .put('/path/to/file-2.ext', 'rld 123')
+                    .reply(201);
+
+                await uploadMultiPartFileConcurrently('test-transfer-file-20.dat', {
+                    urls: [
+                        'http://timeout-error/path/to/file-1.ext',
+                        'http://timeout-error/path/to/file-2.ext'
+                    ],
+                    maxPartSize: 8,
+                }, {
+                    timeout: 200,
+                    retryEnabled: false
+                });
+
+                assert.fail('failure expected');
+            } catch (e) {
+                assert.ok(e.message.includes('PUT'));
+                assert.ok(e.message.includes('connect failed'));
+                assert.ok(e.message.includes('network timeout'));
+            }
+
+            try {
+                await fs.unlink('test-transfer-file-20.dat');
+            } catch (e) { // ignore cleanup failures
+                console.log(e);
+            }
+        });
+        it('timeout-error-2', async function () {
+            await fs.writeFile('test-transfer-file-21.dat', 'hello world 123', 'utf8');
+
+            try {
+                nock('http://timeout-error')
+                    .matchHeader('content-length', 8)
+                    .put('/path/to/file-1.ext', 'hello wo')
+                    .reply(201);
+                nock('http://timeout-error')
+                    .matchHeader('content-length', 7)
+                    .put('/path/to/file-2.ext', 'rld 123')
+                    .delayConnection(500)
+                    .reply(201);
+
+                await uploadMultiPartFileConcurrently('test-transfer-file-21.dat', {
+                    urls: [
+                        'http://timeout-error/path/to/file-1.ext',
+                        'http://timeout-error/path/to/file-2.ext'
+                    ],
+                    maxPartSize: 8,
+                }, {
+                    timeout: 200,
+                    retryEnabled: false
+                });
+
+                assert.fail('failure expected');
+            } catch (e) {
+                assert.ok(e.message.includes('PUT'));
+                assert.ok(e.message.includes('connect failed'));
+                assert.ok(e.message.includes('network timeout'));
+            }
+
+            try {
+                await fs.unlink('test-transfer-file-21.dat');
+            } catch (e) { // ignore cleanup failures
+                console.log(e);
+            }
+        });
+        it('header-override', async function () {
+            await fs.writeFile('test-transfer-file-22.dat', 'hello world 123', 'utf8');
+
+            nock('http://header-override')
+                .matchHeader('content-length', 8)
+                .matchHeader('content-type', 'image/jpeg')
+                .put('/path/to/file-1.ext', 'hello wo')
+                .reply(201);
+            nock('http://header-override')
+                .matchHeader('content-length', 7)
+                .matchHeader('content-type', 'image/jpeg')
+                .put('/path/to/file-2.ext', 'rld 123')
+                .reply(201);
+
+            await uploadMultiPartFileConcurrently('test-transfer-file-22.dat', {
+                urls: [
+                    'http://header-override/path/to/file-1.ext',
+                    'http://header-override/path/to/file-2.ext'
+                ],
+                maxPartSize: 8,
+            }, {
+                headers: {
+                    "content-type": "image/jpeg"
+                }
+            });
+
+            try {
+                await fs.unlink('test-transfer-file-22.dat');
+            } catch (e) { // ignore cleanup failures
+                console.log(e);
+            }
+        });
+        it('status-404-retry', async function () {
+            await fs.writeFile('test-transfer-file-23.dat', 'hello world 123', 'utf8');
+
+            nock('http://status-404-retry')
+                .matchHeader('content-length', 8)
+                .put('/path/to/file-1.ext', 'hello wo')
+                .reply(404);
+            nock('http://status-404-retry')
+                .matchHeader('content-length', 8)
+                .put('/path/to/file-1.ext', 'hello wo')
+                .reply(201);
+            nock('http://status-404-retry')
+                .matchHeader('content-length', 7)
+                .put('/path/to/file-2.ext', 'rld 123')
+                .reply(404);
+            nock('http://status-404-retry')
+                .matchHeader('content-length', 7)
+                .put('/path/to/file-2.ext', 'rld 123')
+                .reply(201);
+
+            await uploadMultiPartFileConcurrently('test-transfer-file-23.dat', {
+                urls: [
+                    'http://status-404-retry/path/to/file-1.ext',
+                    'http://status-404-retry/path/to/file-2.ext'
+                ],
+                maxPartSize: 8,
+            }, {
+                retryAllErrors: true
+            });
+
+            try {
+                await fs.unlink('test-transfer-file-23.dat');
+            } catch (e) { // ignore cleanup failures
+                console.log(e);
+            }
+        });
+        it('status-503-retry', async function () {
+            await fs.writeFile('test-transfer-file-24.dat', 'hello world 123', 'utf8');
+
+            nock('http://status-503-retry')
+                .matchHeader('content-length', 8)
+                .put('/path/to/file-1.ext', 'hello wo')
+                .reply(503);
+            nock('http://status-503-retry')
+                .matchHeader('content-length', 8)
+                .put('/path/to/file-1.ext', 'hello wo')
+                .reply(201);
+            nock('http://status-503-retry')
+                .matchHeader('content-length', 7)
+                .put('/path/to/file-2.ext', 'rld 123')
+                .reply(503);
+            nock('http://status-503-retry')
+                .matchHeader('content-length', 7)
+                .put('/path/to/file-2.ext', 'rld 123')
+                .reply(201);
+
+            await uploadMultiPartFileConcurrently('test-transfer-file-24.dat', {
+                urls: [
+                    'http://status-503-retry/path/to/file-1.ext',
+                    'http://status-503-retry/path/to/file-2.ext'
+                ],
+                maxPartSize: 8,
+            });
+
+            try {
+                await fs.unlink('test-transfer-file-24.dat');
+            } catch (e) { // ignore cleanup failures
+                console.log(e);
+            }
+        }).timeout(10000);
+    });
+
+    it('status-connect-error-retry', async function () {
+        await fs.writeFile('test-transfer-file-24.dat', 'hello world 123', 'utf8');
+
+        nock('http://status-503-retry')
+            .matchHeader('content-length', 8)
+            .put('/path/to/file-1.ext', 'hello wo')
+            .replyWithError({
+                code: 'ECONNRESET',
+                message: 'Connection Reset'
+            });
+        nock('http://status-503-retry')
+            .matchHeader('content-length', 8)
+            .put('/path/to/file-1.ext', 'hello wo')
+            .reply(201);
+        nock('http://status-503-retry')
+            .matchHeader('content-length', 7)
+            .put('/path/to/file-2.ext', 'rld 123')
+            .reply(201);
+
+        await uploadMultiPartFileConcurrently('test-transfer-file-24.dat', {
+            urls: [
+                'http://status-503-retry/path/to/file-1.ext',
+                'http://status-503-retry/path/to/file-2.ext'
+            ],
+            maxPartSize: 8,
+        });
+        console.log(nock.pendingMocks());
+        assert(nock.isDone());
+        try {
+            await fs.unlink('test-transfer-file-24.dat');
+        } catch (e) { // ignore cleanup failures
+            console.log(e);
+        }
+    }).timeout(10000);
+});
+

--- a/test/file.test.js
+++ b/test/file.test.js
@@ -726,7 +726,7 @@ describe('multipart upload concurrently', function () {
                 });
                 assert.fail('expected to fail');
             } catch (e) {
-                assert.ok(e.message.includes('Too large to upload'));
+                assert.ok(e.message.includes('too large to upload'));
             }
 
             try {

--- a/testbed/index.js
+++ b/testbed/index.js
@@ -260,7 +260,7 @@ async function uploadOneBlock(source, target, retryOptions, size) {
  * @param {*} params Additional request parameters
  * @param {*} retryOptions Retry options
  */
-async function uploadMultipleBlocks(source, target, params, retryOptions, size) {
+async function uploadMultipleBlocks(source, target, params, retryOptions) {
     const upload = new BlockUpload();
     const options = {
         uploadFiles: [{


### PR DESCRIPTION
## Description

Goals:
- create `uploadFileConcurrently` to replace `uploadFile`
- create `uploadMultiPartFileConcurrently` to replace `uploadAEMMultipartFile`
- make sure all existing tests pass
- duplicate old `uploadFile` and  `uploadAEMMultipartFile` but using the concurrent versions
   - most passed ootb but there is a small change in behavior with concurrent multipart:
     - If a chunk fails, some or all (depending on concurrency vales) of the multipart chunk requests may be in progress. That is why I had to add nocks for those
- make sure they can be substituted 1:1 for the old functions

### Testing
- tested with `npm link` in the asset-compute-pipeline
- changed upload functions to be the concurrent ones:
   - replace `uploadFile` with  `uploadFileConcurrently`
   -   replace `uploadAEMMultipartFile` with  ` uploadMultiPartFileConcurrently``
- ran npm (only found one behavior break with the `too large` error message: https://github.com/adobe/node-httptransfer/pull/82/commits/4d12ec7e8b16dc5e5f0a8e6662779cc59d4d8fa6 
- after fixing, all tests pass in `asset-compute-pipelin`:
```
 232 passing (7s)
  1 pending
```

test coverage inside node-httptransfer:
(`file.js` upload functions, and `blockupload.js` are all covered)
File                       | % Stmts | % Branch | % Funcs | % Lines | Uncovered Line #s    
---------------------------|---------|----------|---------|---------|----------------------
All files                  |   88.28 |    84.73 |   90.63 |   88.24 |                      
 lib                       |   96.19 |    91.86 |   99.14 |   96.18 |                      
  aemmultipart.js          |     100 |      100 |     100 |     100 |                      
  aempartsize.js           |     100 |      100 |     100 |     100 |                      
  constants.js             |     100 |      100 |     100 |     100 |                      
  error.js                 |     100 |      100 |     100 |     100 |                      
  fetch.js                 |   98.24 |    92.85 |     100 |   98.24 | 95                   
  file.js                  |   90.76 |    88.37 |    92.3 |   90.76 | 38,62,69,103-118     
  filehandle.js            |   86.04 |    61.11 |     100 |   86.04 | 75,95,97,115,137,159 
  headers.js               |     100 |    95.12 |     100 |     100 | 90,124               
  logger.js                |     100 |      100 |     100 |     100 |                      
  randomfileaccess.js      |    92.3 |    81.81 |     100 |    92.3 | 52-53,79             
  retry.js                 |     100 |      100 |     100 |     100 |                      
  stream.js                |     100 |       90 |     100 |     100 | 123                  
  util.js                  |   96.61 |    88.88 |     100 |   96.61 | 32,94                
 lib/aem                   |   99.36 |    98.55 |     100 |   99.36 |                      
  aemdownload.js           |     100 |      100 |     100 |     100 |                      
  aemupload.js             |     100 |    91.66 |     100 |     100 | 121                  
  error-codes.js           |     100 |      100 |     100 |     100 |                      
  upload-error.js          |   98.41 |      100 |     100 |   98.41 | 95                   
 lib/asset                 |   97.91 |    96.85 |     100 |   97.91 |                      
  asset.js                 |     100 |      100 |     100 |     100 |                      
  assetmetadata.js         |     100 |      100 |     100 |     100 |                      
  assetmultipart.js        |     100 |      100 |     100 |     100 |                      
  assetversion.js          |     100 |      100 |     100 |     100 |                      
  nameconflictpolicy.js    |     100 |      100 |     100 |     100 |                      
  transferasset.js         |     100 |    98.11 |     100 |     100 | 240                  
  transferpart.js          |   84.21 |     62.5 |     100 |   84.21 | 38,41,44             
 lib/block                 |    50.8 |    29.88 |   27.27 |    50.8 |                      
  blockdownload.js         |   39.21 |        0 |       0 |   39.21 | 42-84,122-145        
  blockupload.js           |     100 |    89.65 |     100 |     100 | 129,133-158          
  download-error.js        |    3.17 |        0 |       0 |    3.17 | 26-193               
 lib/controller            |   72.72 |     62.5 |   64.28 |   72.72 |                      
  transfercontroller.js    |      75 |       50 |    62.5 |      75 | 44,200-228           
  transferevent.js         |   68.42 |    71.42 |   66.66 |   68.42 | 36,39,42,45,62,80    
 lib/functions             |   88.92 |    89.07 |      88 |   88.84 |                      
  aemcompleteupload.js     |     100 |      100 |     100 |     100 |                      
  aeminitiateupload.js     |     100 |      100 |     100 |     100 |                      
  closefiles.js            |     100 |      100 |     100 |     100 |                      
  failunsupportedassets.js |     100 |      100 |     100 |     100 |                      
  filterfailedassets.js    |     100 |      100 |     100 |     100 |                      
  getassetmetadata.js      |   26.47 |        0 |       0 |   26.47 | 46-100               
  transfer.js              |      92 |    86.11 |     100 |      92 | 64,68,100,124        
  transferpartscreate.js   |     100 |      100 |     100 |     100 |                      
  transferpartsjoin.js     |   96.15 |      100 |     100 |   96.15 | 86                   
 lib/generator             |     100 |      100 |     100 |     100 |                      
  function.js              |     100 |      100 |     100 |     100 |                      
  mapconcurrent.js         |     100 |      100 |     100 |     100 |                      
  pipeline.js              |     100 |      100 |     100 |     100 |                      
---------------------------|---------|----------|---------|---------|----------------------

Fixes # [(issue)](https://jira.corp.adobe.com/browse/NUI-1674)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
