### PR TITLE
CQ-4337713 Request for CSRF token before AEMCompleteUpload and AEMInitiateUpload

### DIFF
--- a/lib/csrf.js
+++ b/lib/csrf.js
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2022 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+"use strict";
+
+const { streamGet } = require("./fetch");
+const { retry } = require("./retry");
+
+/**
+ * Get a CSRF Token from the target Host with options
+ *
+ * @param {String} host Host to get csrf from 
+ * @param {Object} options Fetch options
+ * @param {Object} headers Fetch headers
+ * @returns {String} Token
+ */
+async function getCSRFToken(host, options, headers) {
+    try {
+        const url = `${host}/libs/granite/csrf/token.json`;
+        const result = await retry(async () => {
+            return streamGet(url, {
+                timeout: options && options.timeout,                    
+                headers: headers
+            });
+        }, options);
+
+        return (await result.json()).token;
+    } catch (e) {
+        throw new Error(`Fail to retrieve CSRF token before uploading with err ${e}`);
+    }
+}
+
+module.exports = {
+    getCSRFToken,
+};

--- a/lib/csrf.js
+++ b/lib/csrf.js
@@ -26,16 +26,19 @@ const { retry } = require("./retry");
 async function getCSRFToken(host, options, headers) {
     try {
         const url = `${host}/libs/granite/csrf/token.json`;
-        const result = await retry(async () => {
+        const response = await retry(async () => {
             return streamGet(url, {
                 timeout: options && options.timeout,                    
                 headers: headers
             });
         }, options);
-
-        return (await result.json()).token;
+        
+        if (response.status !== 200) {
+            throw new Error(`Bad response from server ${response.status}`);
+        }
+        return (await response.json()).token;
     } catch (e) {
-        throw new Error(`Fail to retrieve CSRF token before uploading with err ${e}`);
+        throw new Error(`Fail to get CSRF token with err ${e}`);
     }
 }
 

--- a/lib/functions/aemcompleteupload.js
+++ b/lib/functions/aemcompleteupload.js
@@ -43,7 +43,6 @@ class AEMCompleteUpload extends AsyncGeneratorFunction {
     constructor(options) {
         super();
         this.options = options;
-        console.log('AEMCompleteUpload');
     }
 
     /**
@@ -79,15 +78,18 @@ class AEMCompleteUpload extends AsyncGeneratorFunction {
                 form.append("replace", transferAsset.nameConflictPolicy.replace);
                 form.append("uploadToken", uploadToken);
 
+                const headers = transferAsset.target.headers || {};
+
+                // eslint-disable-next-line no-undef
                 if ((typeof window !== 'undefined') && (typeof window.document !== 'undefined')) {
                     const origin = new URL(completeUrl).origin;
-                    transferAsset.target.headers['csrf-token'] = await getCSRFToken(origin, this.options, transferAsset.target.headers);
+                    headers['csrf-token'] = await getCSRFToken(origin, this.options, transferAsset.target.headers);
                 }
 
                 await retry(async () => {
                     return postForm(completeUrl, form, {
                         timeout: this.options && this.options.timeout,                    
-                        headers: transferAsset.target.headers
+                        headers
                     });
                 }, this.options);
                 

--- a/lib/functions/aemcompleteupload.js
+++ b/lib/functions/aemcompleteupload.js
@@ -17,6 +17,7 @@ require("core-js/stable");
 const { AsyncGeneratorFunction } = require("../generator/function");
 const { TransferEvents } = require("../controller/transfercontroller");
 const { postForm } = require("../fetch");
+const { getCSRFToken } = require("../csrf");
 const { retry } = require("../retry");
 const { MIMETYPE } = require("../constants");
 
@@ -42,6 +43,7 @@ class AEMCompleteUpload extends AsyncGeneratorFunction {
     constructor(options) {
         super();
         this.options = options;
+        console.log('AEMCompleteUpload');
     }
 
     /**
@@ -76,7 +78,12 @@ class AEMCompleteUpload extends AsyncGeneratorFunction {
                 }
                 form.append("replace", transferAsset.nameConflictPolicy.replace);
                 form.append("uploadToken", uploadToken);
-            
+
+                if ((typeof window !== 'undefined') && (typeof window.document !== 'undefined')) {
+                    const origin = new URL(completeUrl).origin;
+                    transferAsset.target.headers['csrf-token'] = await getCSRFToken(origin, this.options, transferAsset.target.headers);
+                }
+
                 await retry(async () => {
                     return postForm(completeUrl, form, {
                         timeout: this.options && this.options.timeout,                    

--- a/lib/functions/aeminitiateupload.js
+++ b/lib/functions/aeminitiateupload.js
@@ -20,6 +20,7 @@ const { AsyncGeneratorFunction } = require("../generator/function");
 const UploadError = require("../block/upload-error");
 const ErrorCodes = require("../http-error-codes");
 const { postForm } = require("../fetch");
+const { getCSRFToken } = require("../csrf");
 const { retry } = require("../retry");
 const logger = require("../logger");
 const { TransferEvents } = require("../controller/transfercontroller");
@@ -46,6 +47,7 @@ class AEMInitiateUpload extends AsyncGeneratorFunction {
     constructor(options) {
         super();
         this.options = options;
+        console.log('AEMInitiateUpload');
     }
 
     /**
@@ -89,6 +91,12 @@ class AEMInitiateUpload extends AsyncGeneratorFunction {
 
         try {
             const folderUrl = assets[0].target.folderUrl;
+
+            if ((typeof window !== 'undefined') && (typeof window.document !== 'undefined')) {
+                const origin = new URL(folderUrl).origin;
+                assets[0].target.headers['csrf-token'] = await getCSRFToken(origin, this.options, assets[0].target.headers);
+            }
+
             const initiateResponse = await retry(async () => {
                 return postForm(`${folderUrl}.initiateUpload.json`, form, {
                     timeout: this.options && this.options.timeout,

--- a/lib/functions/aeminitiateupload.js
+++ b/lib/functions/aeminitiateupload.js
@@ -47,7 +47,6 @@ class AEMInitiateUpload extends AsyncGeneratorFunction {
     constructor(options) {
         super();
         this.options = options;
-        console.log('AEMInitiateUpload');
     }
 
     /**
@@ -91,16 +90,18 @@ class AEMInitiateUpload extends AsyncGeneratorFunction {
 
         try {
             const folderUrl = assets[0].target.folderUrl;
+            const headers = assets[0].target.headers || {};
 
+            // eslint-disable-next-line no-undef
             if ((typeof window !== 'undefined') && (typeof window.document !== 'undefined')) {
                 const origin = new URL(folderUrl).origin;
-                assets[0].target.headers['csrf-token'] = await getCSRFToken(origin, this.options, assets[0].target.headers);
+                headers['csrf-token'] = await getCSRFToken(origin, this.options, assets[0].target.headers);
             }
 
             const initiateResponse = await retry(async () => {
                 return postForm(`${folderUrl}.initiateUpload.json`, form, {
                     timeout: this.options && this.options.timeout,
-                    headers: assets[0].target.headers
+                    headers
                 });
             }, this.options);
             if (!Array.isArray(initiateResponse.files)) {

--- a/test/csrf.test.js
+++ b/test/csrf.test.js
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2022 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+/* eslint-env mocha */
+
+'use strict';
+
+const nock = require('nock');
+const assert = require('assert');
+const { getCSRFToken } = require('../lib/csrf');
+
+describe('csrf', function () {
+    beforeEach(async function () {
+        nock.cleanAll();
+    });
+
+    afterEach(async function () {
+        assert.ok(nock.isDone(), 'check if all nocks have been used');
+        nock.cleanAll();
+    });
+
+    it('success', async function () {
+        nock('http://test')
+            .get('/libs/granite/csrf/token.json')
+            .reply(200, '{ "token": "test-csrf-token" }');
+
+        const token = await getCSRFToken("http://test");
+        assert.strictEqual(token, 'test-csrf-token');
+    });
+
+    it('throw expected error', async function () {
+        nock('http://test')
+            .get('/libs/granite/csrf/token.json')
+            .reply(400, '');
+
+        assert.rejects(getCSRFToken("http://test"),
+            `Error: Fail to get CSRF token with err Error: GET 'http://test/libs/granite/csrf/token.json' failed with status 400`);
+    });
+});

--- a/test/csrf.test.js
+++ b/test/csrf.test.js
@@ -42,7 +42,22 @@ describe('csrf', function () {
             .get('/libs/granite/csrf/token.json')
             .reply(400, '');
 
-        assert.rejects(getCSRFToken("http://test"),
-            `Error: Fail to get CSRF token with err Error: GET 'http://test/libs/granite/csrf/token.json' failed with status 400`);
+        await assert.rejects(getCSRFToken("http://test"), err => {
+            assert.strictEqual(err.message,
+                `Fail to get CSRF token with err Error: GET 'http://test/libs/granite/csrf/token.json' failed with status 400`);
+            return true;
+        });
+    });
+
+    it('throw expected error with 2xx response other than 200', async function () {
+        nock('http://test')
+            .get('/libs/granite/csrf/token.json')
+            .reply(201, '');
+        
+        await assert.rejects(getCSRFToken("http://test"), err => {
+            assert.strictEqual(err.message,
+                `Fail to get CSRF token with err Error: Bad response from server 201`);
+            return true;
+        });
     });
 });


### PR DESCRIPTION
## Description
Request for CSRF before token AEMCompleteUpload and AEMInitiateUpload in browser.
This is tested together with `@adobe/aem-upload` package and an AppBuilder React App using `npm link`. 

<img width="431" alt="Screen Shot 2022-01-12 at 1 40 44 PM" src="https://user-images.githubusercontent.com/11958538/149225533-fabd50ef-dd7f-4882-a836-d17d0a6b49b5.png">

Fixes # (CQ-4337713)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

