### PR TITLE
[ASSETS-4407][ASSETS-211] add better logging on the amount of chunks created per request, add retry on chunks tests

### DIFF
--- a/lib/functions/transferpartscreate.js
+++ b/lib/functions/transferpartscreate.js
@@ -77,7 +77,7 @@ class CreateTransferParts extends AsyncGeneratorFunction {
                         yield transferPart;
                         ++idx;
                     }   
-                    logger.info(`${idx} transfer parts created (multipart target)`);
+                    console.log(`${idx} transfer parts created (multipart target)`);
                 } else if (transferAsset.acceptRanges && isFileProtocol(transferAsset.target.url)) {
                     const targetUrls = [transferAsset.target.url];
                     const partSize = this.preferredPartSize || DEFAULT_FILE_TARGET_PART_SIZE;
@@ -88,7 +88,7 @@ class CreateTransferParts extends AsyncGeneratorFunction {
                         yield transferPart;
                         ++idx;
                     }
-                    logger.info(`${idx} transfer parts created (target uses file protocol)`);
+                    console.log(`${idx} transfer parts created (target uses file protocol)`);
                 } else {
                     const targetUrls = [transferAsset.target.url];
                     const contentRange = new DRange(0, contentLength - 1);

--- a/test/file-concurrently.test.js
+++ b/test/file-concurrently.test.js
@@ -538,7 +538,7 @@ describe('download concurrently', function () {
                 'content-type': 'text/plain',
                 'content-length': 1
             });
-        // `e` fails at first with 503
+        // `a` fails at first with 503
         nock('http://test-status-503', {
             reqheaders: {
                 'range': 'bytes=1-1'
@@ -580,7 +580,7 @@ describe('download concurrently', function () {
         } catch (e) {
             console.log(e);
         }
-    }).timeout(10000);
+    });
     it('status-etimedout-one-chunk-fails', async function () {
         nock('http://test-status-etimedout', {
             reqheaders: {
@@ -592,7 +592,7 @@ describe('download concurrently', function () {
                 'content-type': 'text/plain',
                 'content-length': 1
             });
-        // `e` fails at first with etimedout
+        // `a` fails at first with etimedout
         nock('http://test-status-etimedout', {
             reqheaders: {
                 'range': 'bytes=1-1'
@@ -636,7 +636,7 @@ describe('download concurrently', function () {
         } catch (e) {
             console.log(e);
         }
-    }).timeout(10000);
+    });
 
     it('timeout-retry', async function () {
         nock('http://test-status-timeout')


### PR DESCRIPTION
## Description

Now it will show how many transfer parts are created (chunks to be downloaded) per request:
```
5 transfer parts created (target uses file protocol)
```
This is important to track in logs since we are changing the preferred part sizes.

Also added some download tests with multiple parts and a retry test for 503s and etimedout. I am unable to reproduce the issue here: https://jira.corp.adobe.com/browse/ASSETS-4407

related to tickets: https://jira.corp.adobe.com/browse/ASSETS-211, https://jira.corp.adobe.com/browse/ASSETS-4407

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
