### PR TITLE
Feature: Request options for fetch() - RFC

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -5,7 +5,7 @@
         "node": "6.10.3"
       },
       "useBuiltIns": "entry",
-      "corejs": "3",
+      "corejs": "3.7.0",
       "modules": false
     }]
   ],

--- a/lib/aem/aemdownload.js
+++ b/lib/aem/aemdownload.js
@@ -67,6 +67,7 @@ class AEMDownload extends EventEmitter {
      * @property {Boolean} concurrent If true, multiple files in the supplied list of download files will transfer simultaneously. If false, only one file will transfer at a time, and the next file will not begin transferring until the current file finishes.
      * @property {Number} maxConcurrent Maximum number of concurrent HTTP requests that are allowed
      * @property {Number} [preferredPartSize] Preferred part size
+     * @property {*} requestOptions Options that will be passed to fetch
      */
     /**
      * Download files from AEM to local disk
@@ -76,6 +77,7 @@ class AEMDownload extends EventEmitter {
     async downloadFiles(options) {
         const preferredPartSize = options && options.preferredPartSize;
         const maxConcurrent = (options && options.concurrent && options.maxConcurrent) || 1;
+        const requestOptions = options.requestOptions || {};
 
         const controller = new TransferController();
         controller.on(TransferEvents.CREATE_TRANSFER_PARTS, transferEvent => {
@@ -99,8 +101,9 @@ class AEMDownload extends EventEmitter {
             }
         });
 
-        const retryOptions = {
-            retryMaxCount: 5
+        const transferOptions = {
+            retryMaxCount: 5,
+            requestOptions,
         };
 
         // Build and execute pipeline
@@ -108,7 +111,7 @@ class AEMDownload extends EventEmitter {
         try {
             const pipeline = new Pipeline(
                 new CreateTransferParts({ preferredPartSize }),
-                new MapConcurrent(new Transfer(randomFileAccess, retryOptions), { maxConcurrent }),
+                new MapConcurrent(new Transfer(randomFileAccess, transferOptions), { maxConcurrent }),
                 new JoinTransferParts,
                 new CloseFiles(randomFileAccess),
             );

--- a/lib/aem/aemupload.js
+++ b/lib/aem/aemupload.js
@@ -94,6 +94,7 @@ class AEMUpload extends EventEmitter {
      * @property {Boolean} concurrent If true, multiple files in the supplied list of upload files will transfer simultaneously. If false, only one file will transfer at a time, and the next file will not begin transferring until the current file finishes.
      * @property {Number} maxConcurrent Maximum number of concurrent HTTP requests that are allowed
      * @property {Number} [preferredPartSize] Preferred part size
+     * @property {*} requestOptions Options that will be passed to fetch
      */
     /**
      * Upload files to AEM
@@ -103,6 +104,7 @@ class AEMUpload extends EventEmitter {
     async uploadFiles(options) {
         const preferredPartSize = options && options.preferredPartSize;
         const maxConcurrent = (options && options.concurrent && options.maxConcurrent) || 1;
+        const requestOptions = options.requestOptions || {};
 
         const controller = new TransferController();
         controller.on(TransferEvents.AEM_INITIATE_UPLOAD, transferEvent => {
@@ -126,8 +128,9 @@ class AEMUpload extends EventEmitter {
             }
         });
 
-        const retryOptions = {
-            retryMaxCount: 5
+        const transferOptions = {
+            retryMaxCount: 5,
+            requestOptions,
         };
         
         // Build and execute pipeline
@@ -135,12 +138,14 @@ class AEMUpload extends EventEmitter {
         try {
             const pipeline = new Pipeline(
                 new FailUnsupportedAssets(),
-                new MapConcurrent(new AEMInitiateUpload(retryOptions), { maxBatchLength: 100 }),
+                new MapConcurrent(new AEMInitiateUpload(transferOptions), { maxBatchLength: 100 }),
+                // finish this part ^
                 new CreateTransferParts({ preferredPartSize }),
-                new MapConcurrent(new Transfer(randomFileAccess, retryOptions), { maxConcurrent }),
+                new MapConcurrent(new Transfer(randomFileAccess, transferOptions), { maxConcurrent }),
                 new JoinTransferParts,
                 new CloseFiles(randomFileAccess),
-                new MapConcurrent(new AEMCompleteUpload(retryOptions)),
+                new MapConcurrent(new AEMCompleteUpload(transferOptions)),
+                // finish this part ^
             );
             pipeline.setFilterFunction(new FilterFailedAssets);
             await executePipeline(pipeline, generateAEMUploadTransferRecords(options), controller);

--- a/lib/functions/transfer.js
+++ b/lib/functions/transfer.js
@@ -77,7 +77,8 @@ class Transfer extends AsyncGeneratorFunction {
                             headers: Object.assign({
                                 [HTTP.HEADER.CONTENT_LENGTH]: buf.length,
                                 [HTTP.HEADER.CONTENT_TYPE]: transferPart.metadata.contentType
-                            }, transferPart.targetHeaders)
+                            }, transferPart.targetHeaders),
+                            ...this.options.requestOptions
                         };
                         // to stay backwards compatible, AEMmultiPart upload supports methods `POST` instead of `PUT`
                         if (this.options && this.options.method) {
@@ -94,7 +95,8 @@ class Transfer extends AsyncGeneratorFunction {
                             headers: Object.assign({
                                 [HTTP.HEADER.CONTENT_LENGTH]: blob.size,
                                 [HTTP.HEADER.CONTENT_TYPE]: transferPart.metadata.contentType
-                            }, transferPart.targetHeaders)
+                            }, transferPart.targetHeaders),
+                            ...this.options.requestOptions
                         };
                         // to stay backwards compatible, AEMmultiPart upload supports methods `POST` instead of `PUT`
                         if (this.options && this.options.method) {
@@ -109,7 +111,8 @@ class Transfer extends AsyncGeneratorFunction {
                         const response = await streamGet(transferPart.source.url, {
                             headers: Object.assign({
                                 [HTTP.HEADER.RANGE]: `${HTTP.RANGE.BYTES}=${contentRange.low}-${contentRange.high}`
-                            }, transferPart.sourceHeaders)
+                            }, transferPart.sourceHeaders),
+                            ...this.options.requestOptions,
                         });
                         const contentLengthStr = response.headers.get(HTTP.HEADER.CONTENT_LENGTH);
                         const contentLength = Number.parseInt(contentLengthStr, 10);


### PR DESCRIPTION
## Description

* ~Replace [node-fetch-npm](https://github.com/npm/node-fetch-npm) with [node-fetch](https://github.com/node-fetch/node-fetch) since the former is deprecated~ Edit: removed this part after talking with @tmathern
* Fix a Babel polyfilling bug
* Add support for a `requestOptions` parameter in `AEMUpload` and `AEMDownload` that will be passed all the way down to `fetch`

My use case for wanting to pass options to `fetch` is that I want to override the http(s) `agent` used to make the request in order to support request proxying.

Fixes # (issue)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
