### PR TITLE
Add Special Character # & support to AEMUpload

### DIFF
--- a/lib/aem/aemupload.js
+++ b/lib/aem/aemupload.js
@@ -34,6 +34,7 @@ const EventEmitter = require("events");
 const UploadError = require("../block/upload-error");
 const { FilterFailedAssets } = require("../functions/filterfailedassets");
 const { IllegalArgumentError } = require("../error");
+const { encodeUrlPath } = require("../util");
 
 /**
  * Generate AEM upload transfer assets
@@ -54,6 +55,12 @@ async function* generateAEMUploadTransferRecords(options) {
             }
             sourceUrl = fileUrl(uploadFile.filePath);
         }
+
+        if (options.supportSpecialCharacters) {
+            const fileUrl = new URL(uploadFile.fileUrl);
+            uploadFile.fileUrl = encodeUrlPath(uploadFile.fileUrl, fileUrl.origin);
+        }
+
         const targetUrl = new URL(uploadFile.fileUrl);
 
         const source = new Asset(sourceUrl);
@@ -94,6 +101,7 @@ class AEMUpload extends EventEmitter {
      * @property {Boolean} concurrent If true, multiple files in the supplied list of upload files will transfer simultaneously. If false, only one file will transfer at a time, and the next file will not begin transferring until the current file finishes.
      * @property {Number} maxConcurrent Maximum number of concurrent HTTP requests that are allowed
      * @property {Number} [preferredPartSize] Preferred part size
+     * @property {Boolean} supportSpecialCharacters If true, adds support for special characters # and & by url encoding the AEM initiateUpload and completeUpload paths, and adjusting checks in FailUnsupportedAssets. If false, no special logic will be performed.
      * @property {Object} requestOptions Options that will be passed to fetch (either node-fetch-npm or native fetch, depending on the context)
      */
     /**
@@ -104,6 +112,7 @@ class AEMUpload extends EventEmitter {
     async uploadFiles(options) {
         const preferredPartSize = options && options.preferredPartSize;
         const maxConcurrent = (options && options.concurrent && options.maxConcurrent) || 1;
+        const supportSpecialCharacters = (options && options.supportSpecialCharacters) || false;
         const requestOptions = options.requestOptions || {};
 
         const controller = new TransferController();
@@ -130,6 +139,7 @@ class AEMUpload extends EventEmitter {
 
         const transferOptions = {
             retryMaxCount: 5,
+            supportSpecialCharacters,
             requestOptions
         };
         
@@ -137,7 +147,7 @@ class AEMUpload extends EventEmitter {
         const randomFileAccess = new RandomFileAccess();
         try {
             const pipeline = new Pipeline(
-                new FailUnsupportedAssets(),
+                new FailUnsupportedAssets(transferOptions),
                 new MapConcurrent(new AEMInitiateUpload(transferOptions), { maxBatchLength: 100 }),
                 new CreateTransferParts({ preferredPartSize }),
                 new MapConcurrent(new Transfer(randomFileAccess, transferOptions), { maxConcurrent }),

--- a/lib/aem/aemupload.js
+++ b/lib/aem/aemupload.js
@@ -44,6 +44,10 @@ const { encodeUrlPath } = require("../util");
  * @yields {TransferAsset} Transfer asset
  */
 async function* generateAEMUploadTransferRecords(options) {
+    if (!options) {
+        throw new IllegalArgumentError('options not provided', options);
+    }
+
     for (const uploadFile of options.uploadFiles) {
         let sourceUrl = uploadFile.blob;
         if (!sourceUrl) {

--- a/lib/aem/aemupload.js
+++ b/lib/aem/aemupload.js
@@ -44,10 +44,6 @@ const { encodeUrlPath } = require("../util");
  * @yields {TransferAsset} Transfer asset
  */
 async function* generateAEMUploadTransferRecords(options) {
-    if (!options) {
-        throw new IllegalArgumentError('options not provided', options);
-    }
-
     for (const uploadFile of options.uploadFiles) {
         let sourceUrl = uploadFile.blob;
         if (!sourceUrl) {
@@ -114,6 +110,10 @@ class AEMUpload extends EventEmitter {
      * @param {AEMUploadOptions} options AEM upload options
      */
     async uploadFiles(options) {
+        if (!options) {
+            throw new IllegalArgumentError('options not provided', options);
+        }
+
         const preferredPartSize = options && options.preferredPartSize;
         const maxConcurrent = (options && options.concurrent && options.maxConcurrent) || 1;
         const supportSpecialCharacters = (options && options.supportSpecialCharacters) || false;

--- a/lib/aem/aemupload.js
+++ b/lib/aem/aemupload.js
@@ -101,7 +101,7 @@ class AEMUpload extends EventEmitter {
      * @property {Boolean} concurrent If true, multiple files in the supplied list of upload files will transfer simultaneously. If false, only one file will transfer at a time, and the next file will not begin transferring until the current file finishes.
      * @property {Number} maxConcurrent Maximum number of concurrent HTTP requests that are allowed
      * @property {Number} [preferredPartSize] Preferred part size
-     * @property {Boolean} supportSpecialCharacters If true, adds support for special characters # and & by url encoding the AEM initiateUpload and completeUpload paths, and adjusting checks in FailUnsupportedAssets. If false, no special logic will be performed.
+     * @property {Boolean} supportSpecialCharacters If true, adds support for special characters # and & by encoding the AEM initiateUpload and completeUpload paths used for URLs, and adjusting checks in FailUnsupportedAssets. If false, no special logic will be performed. Defaults to false.
      * @property {Object} requestOptions Options that will be passed to fetch (either node-fetch-npm or native fetch, depending on the context)
      */
     /**

--- a/lib/constants.js
+++ b/lib/constants.js
@@ -42,5 +42,9 @@ module.exports = {
             GET: "GET",
             HEAD: "HEAD"
         })
+    }),
+    UNSUPPORTED_FILENAME_MATCH: Object.freeze({
+        STANDARD: /[[\]{}&:\\?#|*%]/g,
+        SUPPORT_SPECIAL_CHARACTERS: /[[\]{}:\\?|*%]/g
     })
 };

--- a/lib/functions/aeminitiateupload.js
+++ b/lib/functions/aeminitiateupload.js
@@ -121,7 +121,6 @@ class AEMInitiateUpload extends AsyncGeneratorFunction {
 
             let completeURI = initiateResponse.completeURI;
             if (this.options.supportSpecialCharacters) {
-                // ensure completeUri includes the host and port incase AEM does not return this information
                 completeURI = encodeUrlPath(completeURI, folderUrl);
             }
 

--- a/lib/functions/aeminitiateupload.js
+++ b/lib/functions/aeminitiateupload.js
@@ -35,7 +35,7 @@ const { encodeUrlPath } = require("../util");
  * @property {Number} [retryInterval=100] time between retries, used by exponential backoff (ms)
  * @property {Boolean} [retryEnabled=true] retry on failure enabled
  * @property {Boolean} [retryAllErrors=false] whether or not to retry on all http error codes or just >=500
- * @property {Boolean} [supportSpecialCharacters=false] If true, adds support for special characters # and & by url encoding the AEM initiateUpload and completeUpload paths, and adjusting checks in FailUnsupportedAssets. If false, no special logic will be performed.
+ * @property {Boolean} [supportSpecialCharacters=false] If true, adds support for special characters # and & by encoding the AEM initiateUpload and completeUpload paths used for URLs, and adjusting checks in FailUnsupportedAssets. If false, no special logic will be performed. Defaults to false.
  * @property {Object} [requestOptions] Options that will be passed to fetch (either node-fetch-npm or native fetch, depending on the context)
  */
 /**

--- a/lib/functions/aeminitiateupload.js
+++ b/lib/functions/aeminitiateupload.js
@@ -120,7 +120,7 @@ class AEMInitiateUpload extends AsyncGeneratorFunction {
             const files = initiateResponse.files;
 
             let completeURI = initiateResponse.completeURI;
-            if (this.options.supportSpecialCharacters) {
+            if (this.options && this.options.supportSpecialCharacters) {
                 completeURI = encodeUrlPath(completeURI, folderUrl);
             }
 

--- a/lib/functions/aeminitiateupload.js
+++ b/lib/functions/aeminitiateupload.js
@@ -25,6 +25,7 @@ const { retry } = require("../retry");
 const logger = require("../logger");
 const { TransferEvents } = require("../controller/transfercontroller");
 const { MIMETYPE } = require("../constants");
+const { encodeUrlPath } = require("../util");
 
 /**
  * @typedef {Object} AEMInitiateUploadOptions
@@ -34,6 +35,7 @@ const { MIMETYPE } = require("../constants");
  * @property {Number} [retryInterval=100] time between retries, used by exponential backoff (ms)
  * @property {Boolean} [retryEnabled=true] retry on failure enabled
  * @property {Boolean} [retryAllErrors=false] whether or not to retry on all http error codes or just >=500
+ * @property {Boolean} [supportSpecialCharacters=false] If true, adds support for special characters # and & by url encoding the AEM initiateUpload and completeUpload paths, and adjusting checks in FailUnsupportedAssets. If false, no special logic will be performed.
  * @property {Object} [requestOptions] Options that will be passed to fetch (either node-fetch-npm or native fetch, depending on the context)
  */
 /**
@@ -116,7 +118,15 @@ class AEMInitiateUpload extends AsyncGeneratorFunction {
 
             // yield one or more smaller transfer parts if the source accepts ranges and the content length is large enough
             const files = initiateResponse.files;
-            const completeUrl = new URL(initiateResponse.completeURI, folderUrl);
+
+            let completeURI = initiateResponse.completeURI;
+            if (this.options.supportSpecialCharacters) {
+                // ensure completeUri includes the host and port incase AEM does not return this information
+                completeURI = encodeUrlPath(completeURI, folderUrl);
+            }
+
+            const completeUrl = new URL(completeURI, folderUrl);
+
             for (let i = 0; i < assets.length; ++i) {
                 const transferAsset = assets[i];
                 const { minPartSize, maxPartSize, uploadURIs, mimeType, uploadToken } = files[i];

--- a/lib/functions/failunsupportedassets.js
+++ b/lib/functions/failunsupportedassets.js
@@ -12,6 +12,7 @@
 
 "use strict";
 
+const constants = require("../constants");
 const { UnsupportedFileUploadError } = require("../error");
 const { AsyncGeneratorFunction } = require("../generator/function");
 
@@ -46,7 +47,9 @@ class FailUnsupportedAssets extends AsyncGeneratorFunction {
 
                 // initiate upload rejects these characters
                 const filename = transferAsset.target.filename;
-                const fileNameMatch = (this.options && this.options.supportSpecialCharacters) ? /[[\]{}:\\?|*%]/g : /[[\]{}&:\\?#|*%]/g;
+                const fileNameMatch = (this.options && this.options.supportSpecialCharacters) ?
+                    constants.UNSUPPORTED_FILENAME_MATCH.SUPPORT_SPECIAL_CHARACTERS:
+                    constants.UNSUPPORTED_FILENAME_MATCH.STANDARD;
                 if (filename.match(fileNameMatch)) {
                     throw new UnsupportedFileUploadError(`Filename '${filename}' has unsupported characters`);
                 }

--- a/lib/functions/failunsupportedassets.js
+++ b/lib/functions/failunsupportedassets.js
@@ -24,11 +24,9 @@ class FailUnsupportedAssets extends AsyncGeneratorFunction {
      *
      * @param {AEMInitiateUploadOptions} [options] Options to configure supported assets, optional
      */
-    constructor(options) {
+    constructor(options = {}) {
         super();
-        if (options) {
-            this.options = options;
-        }
+        this.options = options;
     }
   
     /**

--- a/lib/functions/failunsupportedassets.js
+++ b/lib/functions/failunsupportedassets.js
@@ -20,6 +20,18 @@ const { AsyncGeneratorFunction } = require("../generator/function");
  */
 class FailUnsupportedAssets extends AsyncGeneratorFunction {
     /**
+     * Construct the FailUnsupportedAssets function.
+     *
+     * @param {AEMInitiateUploadOptions} [options] Options to configure supported assets, optional
+     */
+    constructor(options) {
+        super();
+        if (options) {
+            this.options = options;
+        }
+    }
+  
+    /**
      * Fail unsupported assets
      * 
      * @param {TransferAsset[]|AsyncGenerator|Generator} transferAssets Transfer assets
@@ -36,7 +48,8 @@ class FailUnsupportedAssets extends AsyncGeneratorFunction {
 
                 // initiate upload rejects these characters
                 const filename = transferAsset.target.filename;
-                if (filename.match(/[[\]{}&:\\?#|*%]/g)) {
+                const fileNameMatch = (this.options && this.options.supportSpecialCharacters) ? /[[\]{}:\\?|*%]/g : /[[\]{}&:\\?#|*%]/g;
+                if (filename.match(fileNameMatch)) {
                     throw new UnsupportedFileUploadError(`Filename '${filename}' has unsupported characters`);
                 }
 

--- a/lib/util.js
+++ b/lib/util.js
@@ -222,6 +222,44 @@ function urlToPath(path) {
     };
 }
 
+/**
+ * Encodes each part of a URL path individually, without the slashes.
+ * Only supports http/https URLs. Special precautions are taken to support
+ * special characters # and &. Ensures that encoding happens only once, 
+ * first by decoding and then re-encoding path parts.
+ *
+ * @param {String} path absolute URI whose path will be URL encoded. For example:
+ *  https://myInstance/content/dam/myAsset.jpg
+ * @returns {String} absolute URI whose path has been URL encoded.
+ */
+function encodeUrlPath(path, base) {
+
+    const url = new URL(path, base);
+
+    if (url.protocol !== 'http:' && url.protocol !== 'https:' ) {
+        throw new Error(`only http/https urls are supported; url: ${path}`);
+    }
+
+    // retrieve URL path by taking section after origin - supports http paths with the # special
+    //  character, which otherwise are split between URL.pathname and URL.hash; special precautions
+    //  taken to remove ? query strings
+    let urlPath;
+    const queryStringIndex = path.toString().indexOf('?');
+    if (queryStringIndex === -1) {
+        urlPath = path.toString().substring(url.origin.length);
+    } else {
+        urlPath = path.toString().substring(url.origin.length, queryStringIndex);
+    }
+
+    // ensures URL is encoded only once by decoding and re-encoding
+    const encodedUrlArray = urlPath.split('/').map(part => {
+        part = decodeURIComponent(part);
+        return encodeURIComponent(part);
+    });
+
+    return `${url.origin}${encodedUrlArray.join('/')}`;
+}
+
 module.exports = {
     getFileStats,
     createReadStream,
@@ -232,4 +270,5 @@ module.exports = {
     streamToBuffer,
     urlPathDirname,
     urlToPath,
+    encodeUrlPath,
 };

--- a/lib/util.js
+++ b/lib/util.js
@@ -244,11 +244,11 @@ function encodeUrlPath(path, base) {
     //  character, which otherwise are split between URL.pathname and URL.hash; special precautions
     //  taken to remove ? query strings
     let urlPath;
-    const queryStringIndex = path.toString().indexOf('?');
+    const queryStringIndex = url.toString().indexOf('?');
     if (queryStringIndex === -1) {
-        urlPath = path.toString().substring(url.origin.length);
+        urlPath = url.toString().substring(url.origin.length);
     } else {
-        urlPath = path.toString().substring(url.origin.length, queryStringIndex);
+        urlPath = url.toString().substring(url.origin.length, queryStringIndex);
     }
 
     // ensures URL is encoded only once by decoding and re-encoding

--- a/lib/util.js
+++ b/lib/util.js
@@ -17,7 +17,7 @@ require("core-js/stable");
 const { sep, dirname: filePathDirname, basename: filePathBasename } = require("path");
 const fs = require("fs");
 const validUrl = require("valid-url");
-const { HttpStreamError } = require("./error");
+const { HttpStreamError, UnsupportedFileUploadError } = require("./error");
 
 /**
  * Get the file stats (asynchronously)
@@ -223,13 +223,13 @@ function urlToPath(path) {
 }
 
 /**
- * Encodes each part of a URL path individually, without the slashes.
- * Only supports http/https URLs. Special precautions are taken to support
- * special characters # and &. Ensures that encoding happens only once, 
- * first by decoding and then re-encoding path parts.
+ * URL encodes each part of a URL path individually in order to support special
+ * characters # and &. Only http/https URLs are supported. Ensures that
+ * encoding happens only once, first by decoding and then re-encoding path parts.
  *
- * @param {String} path absolute URI whose path will be URL encoded. For example:
- *  https://myInstance/content/dam/myAsset.jpg
+ * @param {String} path absolute URI whose path will be URL encoded. Supplied path
+ *  must be an absolute URL with protocal and host. For example:
+ *  https://host/path/to-be/encoded/myAsset.jpg
  * @returns {String} absolute URI whose path has been URL encoded.
  */
 function encodeUrlPath(path, base) {
@@ -237,7 +237,7 @@ function encodeUrlPath(path, base) {
     const url = new URL(path, base);
 
     if (url.protocol !== 'http:' && url.protocol !== 'https:' ) {
-        throw new Error(`only http/https urls are supported; url: ${path}`);
+        throw new UnsupportedFileUploadError(`only http/https urls are supported; url: ${path}`);
     }
 
     // retrieve URL path by taking section after origin - supports http paths with the # special

--- a/lib/util.js
+++ b/lib/util.js
@@ -228,7 +228,7 @@ function urlToPath(path) {
  * encoding happens only once, first by decoding and then re-encoding path parts.
  *
  * @param {String} path absolute URI whose path will be URL encoded. Supplied path
- *  must be an absolute URL with protocal and host. For example:
+ *  must be an absolute URL with protocol and host. For example:
  *  https://host/path/to-be/encoded/myAsset.jpg
  * @returns {String} absolute URI whose path has been URL encoded.
  */
@@ -237,7 +237,7 @@ function encodeUrlPath(path, base) {
     const url = new URL(path, base);
 
     if (url.protocol !== 'http:' && url.protocol !== 'https:' ) {
-        throw new UnsupportedFileUploadError(`only http/https urls are supported; url: ${path}`);
+        throw new UnsupportedFileUploadError(`only http/https urls are supported for encoding; url: ${path}`);
     }
 
     // retrieve URL path by taking section after origin - supports http paths with the # special

--- a/test/aem/aemupload.test.js
+++ b/test/aem/aemupload.test.js
@@ -284,4 +284,209 @@ describe('AEM Upload', function() {
             name: 'IllegalArgumentException'
         });
     });
+
+    it('AEM upload special characters in target path', async function() {
+        await setupAemUploadTest('/path/with # special characters/included','file-1.jpg', true);
+        await setupAemUploadTest('/path/with & special characters','file-1.jpg', true);
+        await setupAemUploadTest('/path/with + special characters/included','file-1.jpg', true);
+        await setupAemUploadTest('/path/with ( special characters','file-1.jpg', true);
+        await setupAemUploadTest('/path/with ) special characters/included','file-1.jpg', true);
+        await setupAemUploadTest('/path/with # special & characters (+)','file-1.jpg', true);
+    });
+
+    it('AEM upload special characters in target path and asset name', async function() {
+        await setupAemUploadTest('/path/with # special characters','file-1 #.jpg', true);
+        await setupAemUploadTest('/path/with & special characters/included','file-1 &.jpg', true);
+        await setupAemUploadTest('/path/with + special characters','file-1 +.jpg', true);
+        await setupAemUploadTest('/path/with ( special characters','file-1 (.jpg', true);
+        await setupAemUploadTest('/path/with ) special characters/included','file-1 ).jpg', true);
+        await setupAemUploadTest('/path/with # special & characters (+)','file-1 # & + ( ).jpg', true);
+    });
+
+    it('AEM upload special characters target path and asset name already encoded', async function() {
+        await setupAemUploadTest('/path/with%20%23%20special%20characters','file-1%20%23.jpg', true);
+    });
+
+    it('AEM upload special characters unicode in target path and asset name', async function() {
+        await setupAemUploadTest('/path/ഘങചഛ/থদধনপ','໓໔໕໖.jpg', true);
+    });
+
+    it('AEM upload special characters in asset name, special character support disabled', async function() {
+        const testFile = Path.join(__dirname, 'file-1.jpg');
+        await fs.writeFile(testFile, 'hello world 123', 'utf8');
+        const aemUpload = new AEMUpload();
+        
+        const events = {
+            filestart: [],
+            fileprogress:[],
+            fileend: [],
+            fileerror: []
+        };
+        aemUpload.on('fileerror', (data) => {
+            events.fileerror.push(data);
+        });
+        await aemUpload.uploadFiles({
+            uploadFiles: [{
+                fileUrl: `http://test-aem-upload-201/path/to/file-1&.jpg`,
+                filePath: testFile,
+                fileSize: 15
+            }],
+            supportSpecialCharacters: false
+        });
+
+        const errors = events.fileerror[0].errors;
+        assert.strictEqual(errors.length, 1);
+        assert.strictEqual(errors[0].message, "File cannot be uploaded: Filename 'file-1&.jpg' has unsupported characters");
+    });
 });
+
+/**
+ * Mocks a simple AEMUpload and verifies upload event data.
+ *
+ * @param {String} assetPath path to mock asset
+ * @param {String} assetName name of a mock asset
+ * @param {boolean} supportSpecialCharacters if true, special characters will be encoded
+ *  during the test. Otherwise no encoded will be performed.
+ */
+async function setupAemUploadTest(assetPath, assetName, supportSpecialCharacters = false) {
+    
+    /**
+     * Simulates HTML form encoding (application/x-www-form-urlencoded).
+     *
+     * @param {String} value to be encoded
+     * @returns {String} encoded value.
+     */
+    function getFormEncoding(value) {
+        const form = new URLSearchParams();
+        form.append('myKey', decodeURIComponent(value));
+        return form.toString().substring(6);  
+    }
+
+    /**
+     * URL encodes each part of a path individually (exluding the slashes).
+     *
+     * @param {String} path to be URL encoded, e.g. /path/to/myAsset.jpg
+     * @returns {String} path that has been URL encoded.
+     */
+    function encodePathParts(path) {
+        const encodedPathArray = path.split('/').map((part) => {
+            part = decodeURIComponent(part);
+            return encodeURIComponent(part);
+        });
+
+        return encodedPathArray.join('/');
+    }
+
+    const HOST = 'http://test-aem-upload-201';
+    const testFile = Path.join(__dirname, assetName);
+    await fs.writeFile(testFile, 'hello world 123', 'utf8');
+    const initResponse = {
+        completeURI: `${HOST}${assetPath}.completeUpload.json`,
+        folderPath: assetPath,
+        files: [{
+            fileName: assetName,
+            mimeType: 'image/jpeg',
+            uploadToken: 'upload-token',
+            uploadURIs: [
+                `${HOST}/part`
+            ],
+            minPartSize: 10,
+            maxPartSize: 100
+        }]
+    };
+    const initRaw = JSON.stringify(initResponse);
+    
+    nock(HOST)
+        .post(`${encodePathParts(assetPath)}.initiateUpload.json`, `fileName=${getFormEncoding(assetName)}&fileSize=15`)
+        .reply(201, initRaw, {
+            'Content-Length': initRaw.length
+        });
+
+    nock(HOST, {
+        reqheaders: {
+            'content-length': 15,
+            'content-type': 'image/jpeg',
+            partHeader: 'test'
+        }
+    })
+        .put('/part', 'hello world 123')
+        .reply(201);
+
+    nock(HOST)
+        .post(`${encodePathParts(assetPath)}.completeUpload.json`, (body) => {
+            const {
+                fileName,
+                fileSize,
+                mimeType,
+                createVersion,
+                versionLabel,
+                versionComment,
+                replace,
+                uploadToken,
+                uploadDuration
+            } = body;
+            return fileName === decodeURIComponent(assetName) && fileSize === "15" && mimeType === "image/jpeg" &&
+                createVersion === "true" && versionLabel === "versionLabel" && versionComment === "versionComment" &&
+                replace === "false" && uploadToken === "upload-token" && uploadDuration;
+        })
+        .reply(200, '{}');
+
+    const aemUpload = new AEMUpload();
+    const events = {
+        filestart: [],
+        fileprogress:[],
+        fileend: []
+    };
+    aemUpload.on('filestart', (data) => {
+        events.filestart.push(data);
+    });
+    aemUpload.on('fileprogress', (data) => {
+        events.fileprogress.push(data);
+    });
+    aemUpload.on('fileend', (data) => {
+        events.fileend.push(data);
+    });
+    await aemUpload.uploadFiles({
+        uploadFiles: [{
+            fileUrl: `http://test-aem-upload-201${assetPath}/${assetName}`,
+            filePath: testFile,
+            fileSize: 15,
+            createVersion: true,
+            versionLabel: 'versionLabel',
+            versionComment: 'versionComment',
+            multipartHeaders: { partHeader: 'test' },
+        }],
+        headers: {},
+        concurrent: true,
+        maxConcurrent: 5,
+        preferredPartSize: 7,
+        supportSpecialCharacters,
+    });
+
+    try {
+        await fs.unlink(testFile);
+    } catch (e) { // ignore cleanup failures
+        console.log(e);
+    }
+
+    const fileEventData = {
+        fileName: decodeURIComponent(assetName),
+        fileSize: 15,
+        targetFolder: decodeURIComponent(assetPath),
+        targetFile: decodeURIComponent(`${assetPath}/${assetName}`),
+        sourceFolder: __dirname,
+        sourceFile: testFile
+    };
+
+    assert.deepStrictEqual(events.filestart[0], fileEventData);
+    assert.deepStrictEqual(events.fileprogress[0], {
+        ...fileEventData,
+        mimeType: "image/jpeg",
+        transferred: 15
+    });
+    assert.deepStrictEqual(events.fileend[0], {
+        ...fileEventData,
+        mimeType: "image/jpeg",
+    });
+}
+

--- a/test/aem/aemupload.test.js
+++ b/test/aem/aemupload.test.js
@@ -338,6 +338,14 @@ describe('AEM Upload', function() {
         assert.strictEqual(errors.length, 1);
         assert.strictEqual(errors[0].message, "File cannot be uploaded: Filename 'file-1&.jpg' has unsupported characters");
     });
+
+    it('AEM upload without options returns error', async function() {
+        const aemUpload = new AEMUpload();
+        await assert.rejects(async () => aemUpload.uploadFiles(), err => {
+            assert.strictEqual(err.message, 'options not provided: undefined');
+            return true;
+        });
+    });
 });
 
 /**

--- a/test/aem/file-1.jpg
+++ b/test/aem/file-1.jpg
@@ -1,0 +1,1 @@
+hello world 123

--- a/test/aem/file-1.jpg
+++ b/test/aem/file-1.jpg
@@ -1,1 +1,0 @@
-hello world 123

--- a/test/functions/failunsupportedassets.test.js
+++ b/test/functions/failunsupportedassets.test.js
@@ -93,4 +93,81 @@ describe("FailUnsupportedAssets", () => {
         }
         assert.deepStrictEqual(controller.notifications, []);
     });
+    it("supported-plus", async function() {
+        const source = new Asset("file://path/to/file.png");
+        const target = new Asset("https://host/path/to/+upload.png");
+        const inputAsset = new TransferAsset(source, target, {
+            metadata: new AssetMetadata(undefined, "image/png", 1)
+        });
+        const failUnsupportedAssets = new FailUnsupportedAssets;
+        const controller = new ControllerMock;
+        for await (const transferAsset of failUnsupportedAssets.execute([ inputAsset ], controller)) {
+            assert.deepStrictEqual(transferAsset, inputAsset);
+        }
+        assert.deepStrictEqual(controller.notifications, []);
+    });
+    it("unsupported-ampersand", async function() {
+        const source = new Asset("file://path/to/file.png");
+        const target = new Asset("https://host/path/to/%26upload.png");
+        const inputAsset = new TransferAsset(source, target, {
+            metadata: new AssetMetadata(undefined, "image/png", 1)
+        });
+        const failUnsupportedAssets = new FailUnsupportedAssets;
+        const controller = new ControllerMock;
+        for await (const transferAsset of failUnsupportedAssets.execute([ inputAsset ], controller)) {
+            assert.deepStrictEqual(transferAsset, inputAsset);
+        }
+        assert.deepStrictEqual(controller.notifications, [{
+            eventName: "error",
+            functionName: "FailUnsupportedAssets",
+            props: undefined,
+            transferItem: inputAsset,
+            error: "File cannot be uploaded: Filename '&upload.png' has unsupported characters"
+        }]);
+    });
+    it("supported-special-characters-flag-ampersand", async function() {
+        const source = new Asset("file://path/to/file.png");
+        const target = new Asset("https://host/path/to/%26upload.png");
+        const inputAsset = new TransferAsset(source, target, {
+            metadata: new AssetMetadata(undefined, "image/png", 1)
+        });
+        const failUnsupportedAssets = new FailUnsupportedAssets({supportSpecialCharacters: true});
+        const controller = new ControllerMock;
+        for await (const transferAsset of failUnsupportedAssets.execute([ inputAsset ], controller)) {
+            assert.deepStrictEqual(transferAsset, inputAsset);
+        }
+        assert.deepStrictEqual(controller.notifications, []);
+    });
+    it("unsupported-hash", async function() {
+        const source = new Asset("file://path/to/file.png");
+        const target = new Asset("https://host/path/to/%23upload.png");
+        const inputAsset = new TransferAsset(source, target, {
+            metadata: new AssetMetadata(undefined, "image/png", 1)
+        });
+        const failUnsupportedAssets = new FailUnsupportedAssets;
+        const controller = new ControllerMock;
+        for await (const transferAsset of failUnsupportedAssets.execute([ inputAsset ], controller)) {
+            assert.deepStrictEqual(transferAsset, inputAsset);
+        }
+        assert.deepStrictEqual(controller.notifications, [{
+            eventName: "error",
+            functionName: "FailUnsupportedAssets",
+            props: undefined,
+            transferItem: inputAsset,
+            error: "File cannot be uploaded: Filename '#upload.png' has unsupported characters"
+        }]);
+    });
+    it("supported-special-characters-flag-hash", async function() {
+        const source = new Asset("file://path/to/file.png");
+        const target = new Asset("https://host/path/to/%23upload.png");
+        const inputAsset = new TransferAsset(source, target, {
+            metadata: new AssetMetadata(undefined, "image/png", 1)
+        });
+        const failUnsupportedAssets = new FailUnsupportedAssets({supportSpecialCharacters: true});
+        const controller = new ControllerMock;
+        for await (const transferAsset of failUnsupportedAssets.execute([ inputAsset ], controller)) {
+            assert.deepStrictEqual(transferAsset, inputAsset);
+        }
+        assert.deepStrictEqual(controller.notifications, []);
+    });
 });

--- a/test/util.test.js
+++ b/test/util.test.js
@@ -171,7 +171,7 @@ describe("util", function() {
     it('encode url path - only http/https URLs supported', function() {
         assert.strict.throws(() => {
             util.encodeUrlPath('file://path/to/myFile.jpg');
-        }, Error('File cannot be uploaded: only http/https urls are supported; url: file://path/to/myFile.jpg'));
+        }, Error('File cannot be uploaded: only http/https urls are supported for encoding; url: file://path/to/myFile.jpg'));
     });
 
     it('encode url path - non-absolute URL throws error', function() {

--- a/test/util.test.js
+++ b/test/util.test.js
@@ -147,4 +147,36 @@ describe("util", function() {
         assert.strictEqual(util.urlPathDirname('/my/test/path'), '/my/test');
         assert.strictEqual(util.urlPathDirname('/my/test/file.jpg'), '/my/test');
     });
+
+    it('encode url path', function() {
+        const HOST = 'https://myinstance';
+        assert.strictEqual(util.encodeUrlPath(`${HOST}/path/with-no-special-characters/myasset.jpg`), `${HOST}/path/with-no-special-characters/myasset.jpg`);
+
+        // special characters
+        assert.strictEqual(util.encodeUrlPath(`${HOST}/path/with special #characters&/my&&asset+.jpg`), `${HOST}/path/with%20special%20%23characters%26/my%26%26asset%2B.jpg`);
+        // parenthese are not URL encoded
+        assert.strictEqual(util.encodeUrlPath(`${HOST}/path/with-(special)-#characters&/my&&asset+.jpg`), `${HOST}/path/with-(special)-%23characters%26/my%26%26asset%2B.jpg`);
+
+        // query strings
+        assert.strictEqual(util.encodeUrlPath(`${HOST}/path/with#query+string/myasset.jpg?search=asset`), `${HOST}/path/with%23query%2Bstring/myasset.jpg`);
+        assert.strictEqual(util.encodeUrlPath(`${HOST}/path/with#query+string/myasset.jpg?search=asset?two=questionmarks`), `${HOST}/path/with%23query%2Bstring/myasset.jpg`);
+
+        // already encoded
+        assert.strictEqual(util.encodeUrlPath(`${HOST}/path/with-(special)-%23characters%26/my%26%26asset%2B.jpg`), `${HOST}/path/with-(special)-%23characters%26/my%26%26asset%2B.jpg`);
+
+        // unicode
+        assert.strictEqual(util.encodeUrlPath(`${HOST}/path/with-奈懶癩羅蘿-characters/✾✿❀myAsset✽❁.jpg`), `${HOST}/path/with-%EF%A4%8C%EF%A4%8D%EF%A4%8E%EF%A4%8F%EF%A4%90-characters/%E2%9C%BE%E2%9C%BF%E2%9D%80myAsset%E2%9C%BD%E2%9D%81.jpg`);
+    });
+
+    it('encode url path - only http/https URLs supported', function() {
+        assert.strict.throws(() => {
+            util.encodeUrlPath('file://path/to/myFile.jpg');
+        }, Error('File cannot be uploaded: only http/https urls are supported; url: file://path/to/myFile.jpg'));
+    });
+
+    it('encode url path - non-absolute URL throws error', function() {
+        assert.strict.throws(() => {
+            util.encodeUrlPath('/path/to/myFile.jpg');
+        });
+    });
 });


### PR DESCRIPTION
## Description

- Adds support for using special characters `#` and `&` in asset names and paths during the `AEMUpload` process
- Changes only activated if the `supportSpecialCharacters` flag is set on the `AEMUploadOptions` object
- Works by URL encoding the `initiateUpload` and `completeURI` paths during asset upload

Currently working to resolve dependency module test failures - do not appear to be related to changes in this PR

Fixes # ASSETS-16978 and ASSETS-17487

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
