### PR TITLE
BUGFIX-RELEASE: correctly report when direct binary upload is not enabled

### DIFF
--- a/lib/functions/aeminitiateupload.js
+++ b/lib/functions/aeminitiateupload.js
@@ -106,12 +106,10 @@ class AEMInitiateUpload extends AsyncGeneratorFunction {
                     ...this.options.requestOptions
                 });
             }, this.options);
-            if (!Array.isArray(initiateResponse.files)) {
-                throw new UploadError('Target AEM instance must have direct binary upload enabled', ErrorCodes.NOT_SUPPORTED);
-            } else if (!Array.isArray(initiateResponse.files) || (initiateResponse.files.length !== assets.length)) {
+            if (!Array.isArray(initiateResponse.files) || (typeof initiateResponse.completeURI !== "string")) {
+                throw new UploadError('Target AEM instance does not have direct binary upload enabled. Falling back to create asset servlet.', ErrorCodes.NOT_SUPPORTED);
+            } else if (initiateResponse.files.length !== assets.length) {
                 throw Error(`'files' field incomplete in initiateUpload response (expected files: ${assets.length}): ${JSON.stringify(initiateResponse)}`);
-            } else if (typeof initiateResponse.completeURI !== "string") {
-                throw Error(`'completeURI' field invalid in initiateUpload response: ${JSON.stringify(initiateResponse)}`);
             }
 
             // yield one or more smaller transfer parts if the source accepts ranges and the content length is large enough

--- a/test/functions/aeminitiateupload.test.js
+++ b/test/functions/aeminitiateupload.test.js
@@ -509,7 +509,7 @@ describe("AEMInitiateUpload", () => {
         it("files missing", async () => {
             await tryInvalidInitiateUploadResponse({
                 completeURI: "/path/to.completeUpload.json"
-            }, "Target AEM instance must have direct binary upload enabled");
+            }, "Target AEM instance does not have direct binary upload enabled. Falling back to create asset servlet.");
         });
         it("files length mismatch", async () => {
             await tryInvalidInitiateUploadResponse({
@@ -534,7 +534,7 @@ describe("AEMInitiateUpload", () => {
                     mimeType: "image/png",
                     uploadToken: "uploadToken"
                 }]
-            }, "'completeURI' field invalid in initiateUpload response: {\"files\":[{\"minPartSize\":1000,\"maxPartSize\":10000,\"uploadURIs\":[\"http://host/path/to/target.png/block\"],\"mimeType\":\"image/png\",\"uploadToken\":\"uploadToken\"}]}");
+            }, "Target AEM instance does not have direct binary upload enabled. Falling back to create asset servlet.");
         });
         it("completeURI not a string", async () => {
             await tryInvalidInitiateUploadResponse({
@@ -548,7 +548,7 @@ describe("AEMInitiateUpload", () => {
                     uploadToken: "uploadToken"
                 }],
                 completeURI: {}
-            }, "'completeURI' field invalid in initiateUpload response: {\"files\":[{\"minPartSize\":1000,\"maxPartSize\":10000,\"uploadURIs\":[\"http://host/path/to/target.png/block\"],\"mimeType\":\"image/png\",\"uploadToken\":\"uploadToken\"}],\"completeURI\":{}}");
+            }, "Target AEM instance does not have direct binary upload enabled. Falling back to create asset servlet.");
         });
         it("minPartSize missing", async () => {
             await tryInvalidInitiateUploadResponse({


### PR DESCRIPTION
## Description

As described in the linked issue, it appears that AEM may have multiple ways of responding when direct binary upload isn't enabled. This PR modifies the library's logic that reports when direct binary upload isn't enabled to handle these cases.

Fixes #145 

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
