### PR TITLE
Add Proxy requestOptions to CSRF token Request

### DIFF
--- a/lib/csrf.js
+++ b/lib/csrf.js
@@ -19,17 +19,18 @@ const { retry } = require("./retry");
  * Get a CSRF Token from the target Host with options
  *
  * @param {String} host Host to get csrf from 
- * @param {Object} options Fetch options
+ * @param {import('./functions/aeminitiateupload').AEMInitiateUploadOptions} options Upload options
  * @param {Object} headers Fetch headers
  * @returns {String} Token
  */
-async function getCSRFToken(host, options, headers) {
+async function getCSRFToken(host, options = {}, headers) {
     try {
         const url = `${host}/libs/granite/csrf/token.json`;
         const response = await retry(async () => {
             return streamGet(url, {
                 timeout: options && options.timeout,                    
-                headers: headers
+                headers: headers,
+                ...options.requestOptions
             });
         }, options);
         

--- a/lib/functions/getassetmetadata.js
+++ b/lib/functions/getassetmetadata.js
@@ -30,6 +30,7 @@ const { TransferEvents } = require("../controller/transfercontroller");
  * @property {Number} [retryInterval=100] time between retries, used by exponential backoff (ms)
  * @property {Boolean} [retryEnabled=true] retry on failure enabled
  * @property {Boolean} [retryAllErrors=false] whether or not to retry on all http error codes or just >=500
+ * @property {Object} requestOptions Options that will be passed to fetch (either node-fetch-npm or native fetch, depending on the context)
  */
 /**
  * Retrieve asset metadata information from the sources for the transfer asset. 
@@ -87,7 +88,8 @@ class GetAssetMetadata extends AsyncGeneratorFunction {
                             const headers = await getHeaders(source.url, {
                                 timeout: this.options && this.options.timeout,
                                 headers: source.headers,
-                                doGet: source.url.host.includes(".amazonaws.com")
+                                doGet: source.url.host.includes(".amazonaws.com"),
+                                requestOptions: this.options && this.options.requestOptions
                             });
                             transferAsset.acceptRanges = headers.get("accept-ranges") === "bytes";
                             console.log(`Server accepts ranges: ${transferAsset.acceptRanges} (accept-ranges header set to bytes)`);

--- a/lib/functions/getassetmetadata.js
+++ b/lib/functions/getassetmetadata.js
@@ -82,14 +82,14 @@ class GetAssetMetadata extends AsyncGeneratorFunction {
                         console.log(`Transfer asset has all needed metadata to proceed (content-type: ${transferAsset.metadata.contentType}, content length: ${transferAsset.metadata.contentLength})`);
                     } else {
                         console.log("Transfer asset needs to acquire additional metadata. Executing metadata request");
-                        await retry(async () => {
+                        await retry(async (options) => {
                             // S3 doesn't support HEAD requests against presigned URLs
                             // TODO: 0-byte file support for S3 which results in a 416 error
                             const headers = await getHeaders(source.url, {
-                                timeout: this.options && this.options.timeout,
+                                timeout: options && options.timeout,
                                 headers: source.headers,
                                 doGet: source.url.host.includes(".amazonaws.com"),
-                                requestOptions: this.options && this.options.requestOptions
+                                requestOptions: options && options.requestOptions
                             });
                             transferAsset.acceptRanges = headers.get("accept-ranges") === "bytes";
                             console.log(`Server accepts ranges: ${transferAsset.acceptRanges} (accept-ranges header set to bytes)`);

--- a/lib/headers.js
+++ b/lib/headers.js
@@ -23,9 +23,11 @@ const DEFAULT_MS_HEADERS_SOCKET_TIMEOUT = process.env.DEFAULT_MS_SOCKET_TIMEOUT 
 
 async function getHeaders(url, options={}) {
     const timeoutValue = options.timeout || DEFAULT_MS_HEADERS_SOCKET_TIMEOUT;
+    const { requestOptions = {} } = options;
     const fetchOptions = {
         timeout: timeoutValue,
-        headers: { ...options.headers }
+        headers: { ...options.headers },
+        ...requestOptions
     };
 
     if (options.doGet) {
@@ -223,6 +225,7 @@ function parseResourceHeaders(headers) {
  * @property {Number} [retryInterval=100] time between retries, used by exponential backoff (ms)
  * @property {Boolean} [retryEnabled=true] retry on failure enabled
  * @property {Boolean} [retryAllErrors=false] whether or not to retry on all http error codes or just >=500
+ * @property {Object} requestOptions Options that will be passed to fetch (either node-fetch-npm or native fetch, depending on the context)
  */
 /**
  * Retrieve content information

--- a/test/csrf.test.js
+++ b/test/csrf.test.js
@@ -60,4 +60,33 @@ describe('csrf', function () {
             return true;
         });
     });
+
+    it('confirm requestOptions are passed on to fetch', async function () {
+        nock('http://test')
+            .get('/libs/granite/csrf/token.json')
+            .reply(200, function () {
+                assert.strictEqual(this.req.options.agent, 'test');
+                return { token: "test-csrf-token" };
+            });
+
+        const csrfOptions = {
+            requestOptions: {
+                agent: 'test'
+            }
+        };
+
+        await getCSRFToken("http://test", csrfOptions);
+    });
+
+    it('confirm an empty requestOptions does not cause errors', async function () {
+        nock('http://test')
+            .get('/libs/granite/csrf/token.json')
+            .reply(200, '{ "token": "test-csrf-token" }')
+            .persist();
+
+        await getCSRFToken("http://test");
+        await getCSRFToken("http://test", {});
+        await getCSRFToken("http://test", { requestOptions: false });
+        await getCSRFToken("http://test", { requestOptions: {} });
+    });
 });

--- a/test/headers.test.js
+++ b/test/headers.test.js
@@ -415,5 +415,36 @@ describe('headers', function() {
                 assert.ok(e.message.includes('read failure'));
             }
         });
+        it('headers - requestOptions are passed to fetch (used for things like proxy support)', async function() {
+            nock('http://test-headers')
+                .head('/path/to/file.ext')
+                .reply(200, function() {
+                    // confirm requestOptions were sent as part of HEAD request
+                    assert.strictEqual(this.req.options.agent, 'unit-test-agent');
+                });
+
+            const options = {
+                requestOptions: {
+                    agent: 'unit-test-agent'
+                }
+            };
+
+            await getResourceHeaders('http://test-headers/path/to/file.ext', options);
+        });
+        it('headers - empty options do not cause errors', async function() {
+            nock('http://test-headers')
+                .persist()
+                .head('/path/to/file.ext')
+                .reply(200);
+
+            // no options object
+            await getResourceHeaders('http://test-headers/path/to/file.ext');
+
+            // empty options object
+            await getResourceHeaders('http://test-headers/path/to/file.ext', {});
+
+            // empty requestOptions object
+            await getResourceHeaders('http://test-headers/path/to/file.ext', { requestOptions: {} });
+        });
     });
 });


### PR DESCRIPTION
## Description

A customer issue uncovered that the CSRF token request is not receiving the http proxy agent supplied via `requestOptions`, which is being done in other parts of this library. This PR corrects that issue, and also adds `requestOptions` support to one other area where it was missing (`GetAssetMetadata`).

Unit tests have been added and this fix has been confirmed in Asset Link

Fixes # ASSETS-27057

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
