### PR TITLE
add missing semantic release config option

### DIFF
--- a/.releaserc.json
+++ b/.releaserc.json
@@ -19,7 +19,10 @@
           "subject": "BUGFIX-RELEASE:*",
           "release": "patch"
         }
-        ]
+        ],
+        "parserOpts": {
+          "noteKeywords": ["BREAKING-RELEASE", "FEATURE-RELEASE", "BUGFIX-RELEASE"]
+        }
       }],
       ["@semantic-release/release-notes-generator", {
         "preset": "eslint"


### PR DESCRIPTION
## Description

The release of my previous commit failed with the message:

```
Failed step "analyzeCommits" of plugin "@semantic-release/commit-analyzer"
An error occurred while running semantic-release: TypeError: Cannot read properties of undefined (reading 'parserOpts')
```

I updated to the latest version of semantic release and some of its plugins. Upon reviewing the commit-analyzer documentation, it appears that it needs a `parserOpts` value in its custom configuration. This PR adds that.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
